### PR TITLE
[LBOS-1213] ⚙️Reorder toolbox snippets

### DIFF
--- a/pxtblocks/blocklycustomeditor.ts
+++ b/pxtblocks/blocklycustomeditor.ts
@@ -47,6 +47,8 @@ namespace pxt.blocks {
         registerFieldEditor('protractor', pxtblockly.FieldProtractor);
         registerFieldEditor('position', pxtblockly.FieldPosition);
         registerFieldEditor('melody', pxtblockly.FieldCustomMelody);
+        registerFieldEditor('roundMatrix', pxtblockly.FieldRoundMatrix);
+        registerFieldEditor('roundMatrixSmall', pxtblockly.FieldRoundMatrixSmall);
     }
 
     export function registerFieldEditor(selector: string, field: Blockly.FieldCustomConstructor, validator?: any) {

--- a/pxtblocks/fields/field_roundMatrix.ts
+++ b/pxtblocks/fields/field_roundMatrix.ts
@@ -1,0 +1,340 @@
+/// <reference path="../../built/pxtsim.d.ts"/>
+
+namespace pxtblockly {
+
+    export class FieldRoundMatrix extends Blockly.Field implements Blockly.FieldCustom {
+        private static CELL_WIDTH = 25;
+        private static CELL_HORIZONTAL_MARGIN = 7;
+        private static CELL_VERTICAL_MARGIN = 5;
+        private static CELL_CORNER_RADIUS = 5;
+        private static BOTTOM_MARGIN = 9;
+        private static Y_AXIS_WIDTH = 7;
+        private static X_AXIS_HEIGHT = 7;
+        private static TAB = "        ";
+
+        public isFieldCustom_ = true;
+
+        private params: any;
+        private onColor = "#FFFFFF";
+        private offColor: string;
+        private static DEFAULT_OFF_COLOR = "#000000";
+
+        // The number of columns
+        private matrixWidth: number = 5;
+
+        // The number of rows
+        private matrixHeight: number = 5;
+
+        private yAxisLabel: LabelMode = LabelMode.None;
+        private xAxisLabel: LabelMode = LabelMode.None;
+
+        private cellState: boolean[][] = [];
+        private cells: SVGRectElement[][] = [];
+        private elt: SVGSVGElement;
+
+        private currentDragState_: boolean;
+
+        constructor(text: string, params: any, validator?: Function) {
+            super(text, validator);
+            this.params = params;
+
+            if (this.params.rows !== undefined) {
+                let val = parseInt(this.params.rows);
+                if (!isNaN(val)) {
+                    this.matrixHeight = val;
+                }
+            }
+
+            if (this.params.columns !== undefined) {
+                let val = parseInt(this.params.columns);
+                if (!isNaN(val)) {
+                    this.matrixWidth = val;
+                }
+            }
+
+            if (this.params.onColor !== undefined) {
+                this.onColor = this.params.onColor;
+            }
+
+            if (this.params.offColor !== undefined) {
+                this.offColor = this.params.offColor;
+            }
+        }
+
+        /**
+         * Show the inline free-text editor on top of the text.
+         * @private
+         */
+        showEditor_() {
+            // Intentionally left empty
+        }
+
+        private initMatrix() {
+            this.elt = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" />`);
+
+            // Initialize the matrix that holds the state
+            for (let i = 0; i < this.matrixWidth; i++) {
+                this.cellState.push([])
+                this.cells.push([]);
+                for (let j = 0; j < this.matrixHeight; j++) {
+                    this.cellState[i].push(false);
+                }
+            }
+
+            this.restoreStateFromString();
+
+            // Create the cells of the matrix that is displayed
+            for (let i = 0; i < this.matrixWidth; i++) {
+                for (let j = 0; j < this.matrixHeight; j++) {
+                    this.createCell(i, j);
+                }
+            }
+
+            this.updateValue();
+
+            if (this.xAxisLabel !== LabelMode.None) {
+                const y = this.matrixHeight * (FieldRoundMatrix.CELL_WIDTH + FieldRoundMatrix.CELL_VERTICAL_MARGIN) + FieldRoundMatrix.CELL_VERTICAL_MARGIN * 2 + FieldRoundMatrix.BOTTOM_MARGIN
+                const xAxis = pxsim.svg.child(this.elt, "g", { transform: `translate(${0} ${y})` });
+                for (let i = 0; i < this.matrixWidth; i++) {
+                    const x = this.getYAxisWidth() + i * (FieldRoundMatrix.CELL_WIDTH + FieldRoundMatrix.CELL_HORIZONTAL_MARGIN) + FieldRoundMatrix.CELL_WIDTH / 2 + FieldRoundMatrix.CELL_HORIZONTAL_MARGIN / 2;
+                    const lbl = pxsim.svg.child(xAxis, "text", { x, class: "blocklyText" })
+                    lbl.textContent = this.getLabel(i, this.xAxisLabel);
+                }
+            }
+
+            if (this.yAxisLabel !== LabelMode.None) {
+                const yAxis = pxsim.svg.child(this.elt, "g", {});
+                for (let i = 0; i < this.matrixHeight; i++) {
+                    const y = i * (FieldRoundMatrix.CELL_WIDTH + FieldRoundMatrix.CELL_VERTICAL_MARGIN) + FieldRoundMatrix.CELL_WIDTH / 2 + FieldRoundMatrix.CELL_VERTICAL_MARGIN * 2;
+                    const lbl = pxsim.svg.child(yAxis, "text", { x: 0, y, class: "blocklyText" })
+                    lbl.textContent = this.getLabel(i, this.yAxisLabel);
+                }
+            }
+
+            this.fieldGroup_.appendChild(this.elt);
+        }
+
+        private getLabel(index: number, mode: LabelMode) {
+            switch (mode) {
+                case LabelMode.Letter:
+                    return String.fromCharCode(index + /*char code for A*/ 65);
+                default:
+                    return (index + 1).toString();
+            }
+        }
+
+        private dontHandleMouseEvent_ = (ev: MouseEvent) => {
+            ev.stopPropagation();
+            ev.preventDefault();
+        }
+
+        private clearLedDragHandler = (ev: MouseEvent) => {
+            const svgRoot = (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot();
+            pxsim.pointerEvents.down.forEach(evid => svgRoot.removeEventListener(evid, this.dontHandleMouseEvent_));
+            svgRoot.removeEventListener(pxsim.pointerEvents.move, this.dontHandleMouseEvent_);
+            document.removeEventListener(pxsim.pointerEvents.up, this.clearLedDragHandler);
+            document.removeEventListener(pxsim.pointerEvents.leave, this.clearLedDragHandler);
+
+            (Blockly as any).Touch.clearTouchIdentifier();
+
+            this.elt.removeEventListener(pxsim.pointerEvents.move, this.handleRootMouseMoveListener);
+
+            ev.stopPropagation();
+            ev.preventDefault();
+        }
+
+        private createCell(x: number, y: number) {
+            const tx = x * (FieldRoundMatrix.CELL_WIDTH + FieldRoundMatrix.CELL_HORIZONTAL_MARGIN) + FieldRoundMatrix.CELL_HORIZONTAL_MARGIN + this.getYAxisWidth();
+            const ty = y * (FieldRoundMatrix.CELL_WIDTH + FieldRoundMatrix.CELL_VERTICAL_MARGIN) + FieldRoundMatrix.CELL_VERTICAL_MARGIN;
+
+            const isDeadCell = (x ===0 && (y===0 || y ===6) || x ===6 && (y===0 || y ===6))
+            const cellG = pxsim.svg.child(this.elt, "g", { transform: `translate(${tx} ${ty})` }) as SVGGElement;
+            const cellRect = pxsim.svg.child(cellG, "rect", {
+                'class': `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`,
+                'cursor': 'pointer',
+                width: isDeadCell ? 0 : FieldRoundMatrix.CELL_WIDTH ,
+                height: isDeadCell ? 0 : FieldRoundMatrix.CELL_WIDTH,
+                fill: this.getColor(x, y),
+                'data-x': x,
+                'data-y': y,
+                rx: FieldRoundMatrix.CELL_CORNER_RADIUS }) as SVGRectElement;
+            this.cells[x][y] = cellRect;
+
+
+            if ((this.sourceBlock_.workspace as any).isFlyout) return;
+
+            if (!isDeadCell) {
+                pxsim.pointerEvents.down.forEach(evid => cellRect.addEventListener(evid, (ev: MouseEvent) => {
+                    const svgRoot = (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot();
+                    this.currentDragState_ = !this.cellState[x][y];
+
+                    // select and hide chaff
+                    Blockly.hideChaff();
+                    (this.sourceBlock_ as Blockly.BlockSvg).select();
+
+                    this.toggleRect(x, y);
+                    pxsim.pointerEvents.down.forEach(evid => svgRoot.addEventListener(evid, this.dontHandleMouseEvent_));
+                    svgRoot.addEventListener(pxsim.pointerEvents.move, this.dontHandleMouseEvent_);
+
+                    document.addEventListener(pxsim.pointerEvents.up, this.clearLedDragHandler);
+                    document.addEventListener(pxsim.pointerEvents.leave, this.clearLedDragHandler);
+
+                    // Begin listening on the canvas and toggle any matches
+                    this.elt.addEventListener(pxsim.pointerEvents.move, this.handleRootMouseMoveListener);
+
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                }, false));
+            }
+        }
+
+        private toggleRect = (x: number, y: number) => {
+            this.cellState[x][y] = this.currentDragState_;
+            this.updateValue();
+        }
+
+        private handleRootMouseMoveListener = (ev: MouseEvent) => {
+            let clientX;
+            let clientY;
+            if ((ev as any).changedTouches && (ev as any).changedTouches.length == 1) {
+                // Handle touch events
+                clientX = (ev as any).changedTouches[0].clientX;
+                clientY = (ev as any).changedTouches[0].clientY;
+            } else {
+                // All other events (pointer + mouse)
+                clientX = ev.clientX;
+                clientY = ev.clientY;
+            }
+            const target = document.elementFromPoint(clientX, clientY);
+            if (!target) return;
+            const x = target.getAttribute('data-x');
+            const y = target.getAttribute('data-y');
+            if (x != null && y != null) {
+                this.toggleRect(parseInt(x), parseInt(y));
+            }
+        }
+
+        private getColor(x: number, y: number) {
+            return this.cellState[x][y] ? this.onColor : (this.offColor || FieldRoundMatrix.DEFAULT_OFF_COLOR);
+        }
+
+        private getOpacity(x: number, y: number) {
+            return this.cellState[x][y] ? '1.0' : '0.2';
+        }
+
+        private updateCell(x: number, y: number) {
+            const cellRect = this.cells[x][y];
+            cellRect.setAttribute("fill", this.getColor(x, y));
+            cellRect.setAttribute("fill-opacity", this.getOpacity(x, y));
+            cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
+        }
+
+        setValue(newValue: string | number, restoreState = true) {
+            super.setValue(String(newValue));
+            if (this.elt) {
+                if (restoreState) this.restoreStateFromString();
+
+                for (let x = 0; x < this.matrixWidth; x++) {
+                    for (let y = 0; y < this.matrixHeight; y++) {
+                        this.updateCell(x, y);
+                    }
+                }
+            }
+        }
+
+        render_() {
+            if (!this.visible_) {
+                this.size_.width = 0;
+                return;
+            }
+
+            if (!this.elt) {
+                this.initMatrix();
+            }
+
+
+            // The height and width must be set by the render function
+            this.size_.height = Number(this.matrixHeight) * (FieldRoundMatrix.CELL_WIDTH + FieldRoundMatrix.CELL_VERTICAL_MARGIN) + FieldRoundMatrix.CELL_VERTICAL_MARGIN * 2 + FieldRoundMatrix.BOTTOM_MARGIN + this.getXAxisHeight()
+            this.size_.width = Number(this.matrixWidth) * (FieldRoundMatrix.CELL_WIDTH + FieldRoundMatrix.CELL_HORIZONTAL_MARGIN) + this.getYAxisWidth();
+        }
+
+        // The return value of this function is inserted in the code
+        getValue() {
+            // getText() returns the value that is set by calls to setValue()
+            let text = removeQuotes(this.getText());
+            return `\`\n${FieldRoundMatrix.TAB}${text}\n${FieldRoundMatrix.TAB}\``;
+        }
+
+        // Restores the block state from the text value of the field
+        private restoreStateFromString() {
+            let r = this.getText();
+            if (r) {
+                const rows = r.split("\n").filter(r => rowRegex.test(r));
+
+                for (let y = 0; y < rows.length && y < this.matrixHeight; y++) {
+                    let x = 0;
+                    const row = rows[y];
+
+                    for (let j = 0; j < row.length && x < this.matrixWidth; j++) {
+                        if (isNegativeCharacter(row[j])) {
+                            this.cellState[x][y] = false;
+                            x++;
+                        }
+                        else if (isPositiveCharacter(row[j])) {
+                            this.cellState[x][y] = true;
+                            x++;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Composes the state into a string an updates the field's state
+        private updateValue() {
+            let res = "";
+            for (let y = 0; y < this.matrixHeight; y++) {
+                for (let x = 0; x < this.matrixWidth; x++) {
+                    const isDeadCell = (x ===0 && (y===0 || y ===6) || x ===6 && (y===0 || y ===6))
+                    if (isDeadCell) {
+                        res += "_" + " "
+                    } else {
+                        res += (this.cellState[x][y] ? "#" : ".") + " "
+                    }
+                }
+                res += "\n" + FieldRoundMatrix.TAB
+            }
+
+            // Blockly stores the state of the field as a string
+            this.setValue(res, false);
+        }
+
+        private getYAxisWidth() {
+            return this.yAxisLabel === LabelMode.None ? 0 : FieldRoundMatrix.Y_AXIS_WIDTH;
+        }
+
+        private getXAxisHeight() {
+            return this.xAxisLabel === LabelMode.None ? 0 : FieldRoundMatrix.X_AXIS_HEIGHT;
+        }
+    }
+
+    function isPositiveCharacter(c: string) {
+        return c === "#" || c === "*" || c === "1";
+    }
+
+    function isNegativeCharacter(c: string) {
+        return c === "." || c === "_" || c === "0";
+    }
+
+
+    const allQuotes = ["'", '"', "`"];
+
+    function removeQuotes(str: string) {
+        str = str.trim();
+        const start = str.charAt(0);
+        if (start === str.charAt(str.length - 1) && allQuotes.indexOf(start) !== -1) {
+            return str.substr(1, str.length - 2).trim();
+        }
+        return str;
+    }
+
+}

--- a/pxtblocks/fields/field_roundMatrixSmall.ts
+++ b/pxtblocks/fields/field_roundMatrixSmall.ts
@@ -1,0 +1,306 @@
+/// <reference path="../../built/pxtlib.d.ts" />
+
+
+namespace pxtblockly {
+  import svg = pxt.svgUtil;
+
+
+  interface ParsedSpriteEditorOptions {
+      sizes: [number, number][];
+      initColor: number;
+      initWidth: number;
+      initHeight: number;
+  }
+
+  // 32 is specifically chosen so that we can scale the images for the default
+  // sprite sizes without getting browser anti-aliasing
+  const PREVIEW_WIDTH = 64;
+  const PADDING = 5;
+  const BG_PADDING = 4;
+  const BG_WIDTH = BG_PADDING * 2 + PREVIEW_WIDTH;
+  const TOTAL_WIDTH = PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
+  const DEFAULT_COLOR = "#AAA4AE";
+
+  export class FieldRoundMatrixSmall extends Blockly.Field implements Blockly.FieldCustom {
+      public isFieldCustom_ = true;
+
+      private params: ParsedSpriteEditorOptions;
+      private blocksInfo: pxtc.BlocksInfo;
+      private editor: pxtmatrix.SpriteEditor;
+      private state: pxtmatrix.Bitmap;
+      private lightMode: boolean;
+      private undoStack: pxtmatrix.CanvasState[];
+      private redoStack: pxtmatrix.CanvasState[];
+      private colors: string[];
+
+      constructor(text: string, params: any, validator?: Function) {
+          super(text, validator);
+          this.colors = [
+            '#8E07BA','#FF8A00', '#FFC200',
+            '#FFFF00', '#B50000', '#FF0000',
+            '#FF8981', '#FEFFB0', '#6473FE',
+            '#C51973', '#F051A2', '#FFB3FC',
+            '#003E96', '#003EFE', '#00E0FF',
+            '#AEFFFF', '#B9FFB9', '#02FFA9',
+            '#37B800', '#37FF00', '#00ABBF',
+            '#C7C7C7']
+      }
+
+      /**
+       * Initalize values
+       */
+      init() {
+          if (this.fieldGroup_) {
+              // Field has already been initialized once.
+              return;
+          }
+          // Build the DOM.
+          this.fieldGroup_ = Blockly.utils.createSvgElement('g', {}, null);
+          if (!this.visible_) {
+              (this.fieldGroup_ as any).style.display = 'none';
+          }
+
+          if (!this.state) {
+              this.state = new pxtmatrix.Bitmap(7, 7);
+          }
+
+          this.redrawPreview();
+
+          this.updateEditable();
+          (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot().appendChild(this.fieldGroup_);
+
+          // Force a render.
+          this.render_();
+          (this as any).mouseDownWrapper_ = Blockly.bindEventWithChecks_((this as any).getClickTarget_(), "mousedown", this, (this as any).onMouseDown_)
+      }
+
+      /**
+       * Show the inline free-text editor on top of the text.
+       * @private
+       */
+      showEditor_() {
+          const windowSize = goog.dom.getViewportSize();
+          const scrollOffset = goog.style.getViewportPageOffset(document);
+
+          // If there is an existing drop-down someone else owns, hide it immediately and clear it.
+          Blockly.DropDownDiv.hideWithoutAnimation();
+          Blockly.DropDownDiv.clearContent();
+
+          let contentDiv = Blockly.DropDownDiv.getContentDiv() as HTMLDivElement;
+
+          this.editor = new pxtmatrix.SpriteEditor(this.state, this.blocksInfo, this.lightMode, this.colors);
+          this.editor.initializeUndoRedo(this.undoStack, this.redoStack);
+
+          this.editor.render(contentDiv);
+          this.editor.rePaint();
+
+          this.editor.onClose(() => {
+              this.undoStack = this.editor.getUndoStack();
+              this.redoStack = this.editor.getRedoStack();
+              Blockly.DropDownDiv.hideIfOwner(this);
+          });
+
+          this.editor.setActiveColor(1, true);
+        //   if (!this.params.sizes.some(s => s[0] === this.state.width && s[1] === this.state.height)) {
+        //       this.params.sizes.push([this.state.width, this.state.height]);
+        //}
+          this.editor.setSizePresets([[7,7]]);
+
+          goog.style.setHeight(contentDiv, this.editor.outerHeight() + 1);
+          goog.style.setWidth(contentDiv, this.editor.outerWidth() + 1);
+          goog.style.setStyle(contentDiv, "overflow", "hidden");
+          goog.style.setStyle(contentDiv, "max-height", "500px");
+          pxt.BrowserUtils.addClass(contentDiv.parentElement, "sprite-editor-dropdown")
+
+          Blockly.DropDownDiv.setColour("#2c3e50", "#2c3e50");
+          Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_, () => {
+              this.editor.closeEditor();
+              this.state = this.editor.bitmap().image;
+              this.redrawPreview();
+              if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
+                  Blockly.Events.fire(new Blockly.Events.BlockChange(
+                      this.sourceBlock_, 'field', this.name, this.text_, this.getText()));
+              }
+
+              goog.style.setHeight(contentDiv, null);
+              goog.style.setWidth(contentDiv, null);
+              goog.style.setStyle(contentDiv, "overflow", null);
+              goog.style.setStyle(contentDiv, "max-height", null);
+              pxt.BrowserUtils.removeClass(contentDiv.parentElement, "sprite-editor-dropdown");
+              this.editor.removeKeyListeners();
+          });
+
+          this.editor.addKeyListeners();
+          this.editor.layout();
+      }
+
+      private isInFlyout() {
+          return ((this.sourceBlock_.workspace as Blockly.WorkspaceSvg).getParentSvg() as SVGElement).className.baseVal == "blocklyFlyout";
+      }
+
+      render_() {
+          super.render_();
+          this.size_.height = TOTAL_WIDTH
+          this.size_.width = TOTAL_WIDTH;
+      }
+
+      getText() {
+        return pxtmatrix.bitmapToImageLiteral(this.state, pxt.editor.FileType.TypeScript);
+      }
+
+      setText(newText: string) {
+          if (newText == null) {
+              return;
+          }
+          this.parseBitmap(newText);
+          this.redrawPreview();
+
+          super.setText(newText);
+      }
+
+      private redrawPreview() {
+          if (!this.fieldGroup_) return;
+          pxsim.U.clear(this.fieldGroup_);
+
+          const bg = new svg.Rect()
+              .at(PADDING * 2, PADDING * 2)
+              .size(PREVIEW_WIDTH, PREVIEW_WIDTH)
+              .fill("#000000")
+              .stroke("#898989", 1)
+              .corner(8);
+
+          this.fieldGroup_.appendChild(bg.el);
+
+          const cellSize = 64 / 8
+
+          for (let i = 0; i < 7; i++) {
+            for (let j = 0; j< 7 ; j++) {
+              if ( (i==0 && (j==0 || j==6)) || (i==6 && (j==0||j==6))) {
+                continue
+              }
+              const fillColor = this.getColor(this.state.get(i,j))
+              const rect = new svg.Rect()
+                .at((cellSize*i) + PADDING*3, (cellSize*j)+PADDING*3)
+                .size(cellSize - 1, cellSize - 1)
+                .fill(fillColor, 1)
+                .corner(2)
+              this.fieldGroup_.appendChild(rect.el)
+            }
+          }
+
+          if (this.state) {
+              const data = this.renderPreview();
+              const img = new svg.Image()
+                  .src(data)
+                  .at(PADDING + BG_PADDING, PADDING + BG_PADDING)
+                  .size(PREVIEW_WIDTH, PREVIEW_WIDTH);
+              //this.fieldGroup_.appendChild(img.el);
+          }
+      }
+
+      private parseBitmap(newText: string) {
+          const bmp = pxtmatrix.imageLiteralToBitmap(newText);
+
+          // Ignore invalid bitmaps
+          if (bmp && bmp.width && bmp.height) {
+              this.state = bmp;
+          }
+      }
+
+      /**
+       * Scales the image to 32x32 and returns a data uri. In light mode the preview
+       * is drawn with no transparency (alpha is filled with background color)
+       */
+      private renderPreview() {
+          //const colors = pxt.appTarget.runtime.palette.slice(1);
+          const canvas = document.createElement("canvas");
+          canvas.width = PREVIEW_WIDTH;
+          canvas.height = PREVIEW_WIDTH;
+
+          // Works well for all of our default sizes, does not work well if the size is not
+          // a multiple of 2 or is greater than 32 (i.e. from the decompiler)
+          const cellSize = Math.min(PREVIEW_WIDTH / this.state.width, PREVIEW_WIDTH / this.state.height);
+
+          // Center the image if it isn't square
+          const xOffset = Math.max(Math.floor((PREVIEW_WIDTH * (1 - (this.state.width / this.state.height))) / 2), 0);
+          const yOffset = Math.max(Math.floor((PREVIEW_WIDTH * (1 - (this.state.height / this.state.width))) / 2), 0);
+
+          let context: CanvasRenderingContext2D;
+          context = canvas.getContext("2d", { alpha: true });
+          context.fillStyle = "#ff0000";
+          context.beginPath()
+          context.arc(32, 32, 32, 0, 2 * Math.PI, false)
+          context.fill()
+
+          return canvas.toDataURL();
+      }
+
+      private getColor(val : number) {
+        if(val - 1 >= 0 && val - 1 < this.colors.length) {
+            return this.colors[val-1]
+        } else {
+            return DEFAULT_COLOR;
+        }
+      }
+  }
+
+  function parseFieldOptions(opts: FieldSpriteEditorOptions) {
+      const parsed: ParsedSpriteEditorOptions = {
+          sizes: [
+              [8, 8],
+          ],
+          initColor: 1,
+          initWidth: 8,
+          initHeight: 8,
+      };
+
+      if (!opts) {
+          return parsed;
+      }
+
+      if (opts.sizes != null) {
+          const pairs = opts.sizes.split(";");
+          const sizes: [number, number][] = [];
+          for (let i = 0; i < pairs.length; i++) {
+              const pair = pairs[i].split(",");
+              if (pair.length !== 2) {
+                  continue;
+              }
+
+              let width = parseInt(pair[0]);
+              let height = parseInt(pair[1]);
+
+              if (isNaN(width) || isNaN(height)) {
+                  continue;
+              }
+
+              const screenSize = pxt.appTarget.runtime && pxt.appTarget.runtime.screenSize;
+              if (width < 0 && screenSize)
+                  width = screenSize.width;
+              if (height < 0 && screenSize)
+                  height = screenSize.height;
+
+              sizes.push([width, height]);
+          }
+          if (sizes.length > 0) {
+              parsed.sizes = sizes;
+              parsed.initWidth = sizes[0][0];
+              parsed.initHeight = sizes[0][1];
+          }
+      }
+
+      parsed.initColor = withDefault(opts.initColor, parsed.initColor);
+      parsed.initWidth = withDefault(opts.initWidth, parsed.initWidth);
+      parsed.initHeight = withDefault(opts.initHeight, parsed.initHeight);
+
+      return parsed;
+
+      function withDefault(raw: string, def: number) {
+          const res = parseInt(raw);
+          if (isNaN(res)) {
+              return def;
+          }
+          return res;
+      }
+  }
+}

--- a/pxtlib/round-matrix-editor/bitmap.ts
+++ b/pxtlib/round-matrix-editor/bitmap.ts
@@ -1,0 +1,204 @@
+namespace pxtmatrix {
+    // These are the characters used to output literals (but we support aliases for some of these)
+    const hexChars = [".", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"];
+
+    export interface Coord {
+        x: number,
+        y: number
+    }
+
+    /**
+     * 16-color sprite
+     */
+    export class Bitmap {
+        protected buf: Uint8Array;
+
+        constructor(public width: number, public height: number, public x0 = 0, public y0 = 0) {
+            this.buf = new Uint8Array(Math.ceil(width * height / 2));
+        }
+
+        set(col: number, row: number, value: number) {
+            if (col < this.width && row < this.height && col >= 0 && row >= 0) {
+                const index = this.coordToIndex(col, row);
+                this.setCore(index, value);
+            }
+        }
+
+        get(col: number, row: number) {
+            if (col < this.width && row < this.height && col >= 0 && row >= 0) {
+                const index = this.coordToIndex(col, row);
+                return this.getCore(index);
+            }
+            return 0;
+        }
+
+        copy(col = 0, row = 0, width = this.width, height = this.height): Bitmap {
+            const sub = new Bitmap(width, height);
+            sub.x0 = col;
+            sub.y0 = row;
+            for (let c = 0; c < width; c++) {
+                for (let r = 0; r < height; r++) {
+                    sub.set(c, r, this.get(col + c, row + r));
+                }
+            }
+            return sub;
+        }
+
+        apply(change: Bitmap, transparent = false) {
+            let current: number;
+            for (let c = 0; c < change.width; c++) {
+                for (let r = 0; r < change.height; r++) {
+                    current = change.get(c, r);
+
+                    if (!current && transparent) continue;
+                    this.set(change.x0 + c, change.y0 + r, current);
+                }
+            }
+        }
+
+        equals(other: Bitmap) {
+            if (this.width === other.width && this.height === other.height && this.x0 === other.x0 && this.y0 === other.y0 && this.buf.length === other.buf.length) {
+                for (let i = 0; i < this.buf.length; i++) {
+                    if (this.buf[i] !== other.buf[i]) return false;
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        protected coordToIndex(col: number, row: number) {
+            return col + row * this.width;
+        }
+
+        protected getCore(index: number) {
+            const cell = Math.floor(index / 2);
+            if (index % 2 === 0) {
+                return this.buf[cell] & 0xf;
+            }
+            else {
+                return (this.buf[cell] & 0xf0) >> 4;
+            }
+        }
+
+        protected setCore(index: number, value: number) {
+            const cell = Math.floor(index / 2);
+            if (index % 2 === 0) {
+                this.buf[cell] = (this.buf[cell] & 0xf0) | (value & 0xf);
+            }
+            else {
+                this.buf[cell] = (this.buf[cell] & 0x0f) | ((value & 0xf) << 4);
+            }
+        }
+    }
+
+    export class Bitmask {
+        protected mask: Uint8Array;
+
+        constructor(public width: number, public height: number) {
+            this.mask = new Uint8Array(Math.ceil(width * height / 8));
+        }
+
+        set(col: number, row: number) {
+            const cellIndex = col + this.width * row;
+            const index = cellIndex >> 3;
+            const offset = cellIndex & 7;
+            this.mask[index] |= (1 << offset);
+        }
+
+        get(col: number, row: number) {
+            const cellIndex = col + this.width * row;
+            const index = cellIndex >> 3;
+            const offset = cellIndex & 7;
+            return (this.mask[index] >> offset) & 1;
+        }
+    }
+
+    export function resizeBitmap(img: Bitmap, width: number, height: number) {
+        const result = new Bitmap(width, height);
+        result.apply(img);
+        return result;
+    }
+
+    export function imageLiteralToBitmap(text: string, defaultPattern?: string): Bitmap {
+        // Strip the tagged template string business and the whitespace. We don't have to exhaustively
+        // replace encoded characters because the compiler will catch any disallowed characters and throw
+        // an error before the decompilation happens. 96 is backtick and 9 is tab
+        text = text.replace(/[ `]|(?:&#96;)|(?:&#9;)|(?:img)/g, "").trim();
+        text = text.replace(/^["`\(\)]*/, '').replace(/["`\(\)]*$/, '');
+        text = text.replace(/&#10;/g, "\n");
+
+        if (!text && defaultPattern)
+            text = defaultPattern;
+        const rows = text.split("\\n");
+
+        // We support "ragged" sprites so not all rows will be the same length
+        const sprite: number[][] = [];
+        let spriteWidth = 0;
+
+        for (let r = 0; r < rows.length; r++) {
+            const row = rows[r];
+            const rowValues: number[] = [];
+            for (let c = 0; c < row.length; c++) {
+                // This list comes from libs/screen/targetOverrides.ts in pxt-arcade
+                // Technically, this could change per target.
+                switch (row[c]) {
+                    case "0": case ".": rowValues.push(0); break;
+                    case "1": case "#": rowValues.push(1); break;
+                    case "2": case "T": rowValues.push(2); break;
+                    case "3": case "t": rowValues.push(3); break;
+                    case "4": case "N": rowValues.push(4); break;
+                    case "5": case "n": rowValues.push(5); break;
+                    case "6": case "G": rowValues.push(6); break;
+                    case "7": case "g": rowValues.push(7); break;
+                    case "8": rowValues.push(8); break;
+                    case "9": rowValues.push(9); break;
+                    case "a": case "A": case "R": rowValues.push(10); break;
+                    case "b": case "B": case "P": rowValues.push(11); break;
+                    case "c": case "C": case "p": rowValues.push(12); break;
+                    case "d": case "D": case "O": rowValues.push(13); break;
+                    case "e": case "E": case "Y": rowValues.push(14); break;
+                    case "f": case "F": case "W": rowValues.push(15); break;
+                }
+            }
+
+            if (rowValues.length) {
+                sprite.push(rowValues);
+                spriteWidth = Math.max(spriteWidth, rowValues.length);
+            }
+        }
+
+        const spriteHeight = sprite.length;
+
+        const result = new pxtmatrix.Bitmap(spriteWidth, spriteHeight)
+
+        for (let r = 0; r < spriteHeight; r++) {
+            const row = sprite[r];
+            for (let c = 0; c < spriteWidth; c++) {
+                if (c < row.length) {
+                    result.set(c, r, row[c]);
+                }
+                else {
+                    result.set(c, r, 0);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    export function bitmapToImageLiteral(bitmap: Bitmap, fileType: pxt.editor.FileType): string {
+        let res = '`';
+        if (bitmap) {
+            for (let r = 0; r < bitmap.height; r++) {
+                res += "\n"
+                for (let c = 0; c < bitmap.width; c++) {
+                    res += hexChars[bitmap.get(c, r)] + " ";
+                }
+            }
+        }
+
+        res += "`\n";
+        return res;
+    }
+}

--- a/pxtlib/round-matrix-editor/buttons.ts
+++ b/pxtlib/round-matrix-editor/buttons.ts
@@ -1,0 +1,613 @@
+namespace pxtmatrix {
+    import svg = pxt.svgUtil;
+
+    export interface ButtonGroup {
+        root: svg.Group;
+        cx: number;
+        cy: number;
+    }
+
+    const TOGGLE_WIDTH = 200;
+    const TOGGLE_HEIGHT = 40;
+    const TOGGLE_BORDER_WIDTH = 2;
+    const TOGGLE_CORNER_RADIUS = 4;
+
+    const BUTTON_CORNER_RADIUS = 2;
+    const BUTTON_BORDER_WIDTH = 1;
+    const BUTTON_BOTTOM_BORDER_WIDTH = 2;
+
+    export interface ToggleProps {
+        baseColor: string;
+        borderColor: string;
+        backgroundColor: string;
+        switchColor: string;
+        unselectedTextColor: string;
+        selectedTextColor: string;
+
+        leftText: string;
+        leftIcon: string;
+
+        rightText: string;
+        rightIcon: string;
+    }
+
+    export class Toggle {
+        protected leftElement: svg.Group;
+        protected leftText: svg.Text;
+        protected rightElement: svg.Group;
+        protected rightText: svg.Text;
+
+        protected switch: svg.Rect;
+        protected root: svg.Group;
+        protected props: ToggleProps;
+
+        protected isLeft: boolean;
+        protected changeHandler: (left: boolean) => void;
+
+        constructor(parent: svg.SVG, props: Partial<ToggleProps>) {
+            this.props = defaultColors(props);
+            this.root = parent.group();
+            this.buildDom();
+            this.isLeft = true;
+        }
+
+        protected buildDom() {
+            // Our css minifier mangles animation names so they need to be injected manually
+            this.root.style().content(`
+            .toggle-left {
+                transform: translateX(0px);
+                animation: mvleft 0.2s 0s ease;
+            }
+
+            .toggle-right {
+                transform: translateX(100px);
+                animation: mvright 0.2s 0s ease;
+            }
+
+            @keyframes mvright {
+                0% {
+                    transform: translateX(0px);
+                }
+                100% {
+                    transform: translateX(100px);
+                }
+            }
+
+            @keyframes mvleft {
+                0% {
+                    transform: translateX(100px);
+                }
+                100% {
+                    transform: translateX(0px);
+                }
+            }
+            `);
+
+
+            // The outer border has an inner-stroke so we need to clip out the outer part
+            // because SVG's don't support "inner borders"
+            const clip = this.root.def().create("clipPath", "sprite-editor-toggle-border")
+                .clipPathUnits(true);
+
+            clip.draw("rect")
+                .at(0, 0)
+                .corners(TOGGLE_CORNER_RADIUS / TOGGLE_WIDTH, TOGGLE_CORNER_RADIUS / TOGGLE_HEIGHT)
+                .size(1, 1);
+
+            // Draw the outer border
+            this.root.draw("rect")
+                .size(TOGGLE_WIDTH, TOGGLE_HEIGHT)
+                .fill(this.props.baseColor)
+                .stroke(this.props.borderColor, TOGGLE_BORDER_WIDTH * 2)
+                .corners(TOGGLE_CORNER_RADIUS, TOGGLE_CORNER_RADIUS)
+                .clipPath("url(#sprite-editor-toggle-border)");
+
+
+            // Draw the background
+            this.root.draw("rect")
+                .at(TOGGLE_BORDER_WIDTH, TOGGLE_BORDER_WIDTH)
+                .size(TOGGLE_WIDTH - TOGGLE_BORDER_WIDTH * 2, TOGGLE_HEIGHT - TOGGLE_BORDER_WIDTH * 2)
+                .fill(this.props.backgroundColor)
+                .corners(TOGGLE_CORNER_RADIUS, TOGGLE_CORNER_RADIUS);
+
+            // Draw the switch
+            this.switch = this.root.draw("rect")
+                .at(TOGGLE_BORDER_WIDTH, TOGGLE_BORDER_WIDTH)
+                .size((TOGGLE_WIDTH - TOGGLE_BORDER_WIDTH * 2) / 2, TOGGLE_HEIGHT - TOGGLE_BORDER_WIDTH * 2)
+                .fill(this.props.switchColor)
+                .corners(TOGGLE_CORNER_RADIUS, TOGGLE_CORNER_RADIUS);
+
+            // Draw the left option
+            this.leftElement = this.root.group();
+            this.leftText = mkText(this.props.leftText)
+                .appendClass("sprite-editor-text")
+                .fill(this.props.selectedTextColor);
+            this.leftElement.appendChild(this.leftText);
+
+            // Draw the right option
+            this.rightElement = this.root.group();
+            this.rightText = mkText(this.props.rightText)
+                .appendClass("sprite-editor-text")
+                .fill(this.props.unselectedTextColor);
+            this.rightElement.appendChild(this.rightText);
+
+            this.root.onClick(() => this.toggle());
+        }
+
+        toggle(quiet = false) {
+            if (this.isLeft) {
+                this.switch.removeClass("toggle-left");
+                this.switch.appendClass("toggle-right");
+                this.leftText.fill(this.props.unselectedTextColor);
+                this.rightText.fill(this.props.selectedTextColor);
+            }
+            else {
+                this.switch.removeClass("toggle-right");
+                this.switch.appendClass("toggle-left");
+                this.leftText.fill(this.props.selectedTextColor);
+                this.rightText.fill(this.props.unselectedTextColor);
+            }
+            this.isLeft = !this.isLeft;
+
+            if (!quiet && this.changeHandler) {
+                this.changeHandler(this.isLeft);
+            }
+        }
+
+        onStateChange(handler: (left: boolean) => void) {
+            this.changeHandler = handler;
+        }
+
+        layout() {
+            const centerOffset = (TOGGLE_WIDTH - TOGGLE_BORDER_WIDTH * 2) / 4;
+            this.leftText.moveTo(centerOffset + TOGGLE_BORDER_WIDTH, TOGGLE_HEIGHT / 2);
+            this.rightText.moveTo(TOGGLE_WIDTH - TOGGLE_BORDER_WIDTH - centerOffset, TOGGLE_HEIGHT / 2)
+        }
+
+        translate(x: number, y: number) {
+            this.root.translate(x, y);
+        }
+
+        height() {
+            return TOGGLE_HEIGHT;
+        }
+
+        width() {
+            return TOGGLE_WIDTH;
+        }
+    }
+
+    export class Button {
+        cx: number;
+        cy: number;
+        root: svg.Group;
+        clickHandler: () => void;
+        private _title: string;
+        private _shortcut: string;
+
+        constructor(root: svg.Group, cx: number, cy: number) {
+            this.root = root;
+            this.cx = cx;
+            this.cy = cy;
+            this.root.onClick(() => this.clickHandler && this.clickHandler());
+            this.root.appendClass("sprite-editor-button");
+        }
+
+        public getElement() {
+            return this.root;
+        }
+
+        public addClass(className: string) {
+            this.root.appendClass(className);
+        }
+
+        public removeClass(className: string) {
+            this.root.removeClass(className);
+        }
+
+        public onClick(clickHandler: () => void) {
+            this.clickHandler = clickHandler;
+        }
+
+        public translate(x: number, y: number) {
+            this.root.translate(x, y);
+        }
+
+        public title(text: string) {
+            this._title = text;
+            this.setRootTitle();
+        }
+
+        public shortcut(text: string) {
+            this._shortcut = text;
+            this.setRootTitle();
+        }
+
+        private setRootTitle() {
+            this.root.title(this._title + (this._shortcut ? " (" + this._shortcut + ")" : ""));
+        }
+
+        public setDisabled(disabled: boolean) {
+            this.editClass("disabled", disabled);
+        }
+
+        public setSelected(selected: boolean) {
+            this.editClass("selected", selected);
+        }
+
+        protected layout() { /* subclass */ }
+
+        protected editClass(className: string, add: boolean) {
+            if (add) {
+                this.root.appendClass(className);
+            }
+            else {
+                this.root.removeClass(className);
+            }
+        }
+    }
+
+    export class TextButton extends Button {
+        protected textEl: svg.Text;
+
+        constructor(button: ButtonGroup, text: string, className: string) {
+            super(button.root, button.cx, button.cy);
+
+            this.textEl = mkText(text)
+                .appendClass(className);
+
+            this.textEl.moveTo(this.cx, this.cy);
+
+            this.root.appendChild(this.textEl);
+        }
+
+        setText(text: string) {
+            this.textEl.text(text);
+            this.textEl.moveTo(this.cx, this.cy);
+        }
+
+        getComputedTextLength() {
+            try {
+                return this.textEl.el.getComputedTextLength();
+            }
+            catch (e) {
+                // Internet Explorer and Microsoft Edge throw if the element
+                // is not visible. The best we can do is approximate
+                return this.textEl.el.textContent.length * 8;
+            }
+        }
+    }
+
+    export class StandaloneTextButton extends TextButton {
+        protected padding = 30;
+
+        constructor(text: string, readonly height: number) {
+            super(drawSingleButton(65, height), text, "sprite-editor-text");
+            this.addClass("sprite-editor-label");
+        }
+
+        layout() {
+            const newBG = drawSingleButton(this.width(), this.height);
+
+            while (this.root.el.hasChildNodes()) {
+                this.root.el.removeChild(this.root.el.firstChild);
+            }
+
+            while (newBG.root.el.hasChildNodes()) {
+                const el = newBG.root.el.firstChild;
+                newBG.root.el.removeChild(el);
+                this.root.el.appendChild(el);
+            }
+
+            this.cx = newBG.cx;
+            this.cy = newBG.cy;
+
+            this.root.appendChild(this.textEl);
+            this.textEl.moveTo(this.cx, this.cy);
+        }
+
+        width() {
+            return this.getComputedTextLength() + this.padding * 2;
+        }
+    }
+
+    export class CursorButton extends Button {
+        constructor(root: svg.Group, cx: number, cy: number, width: number) {
+            super(root, cx, cy);
+
+            this.root.draw("rect")
+                .fill("white")
+                .size(width, width)
+                .at(Math.floor(this.cx - width / 2), Math.floor(this.cy - width / 2))
+        }
+    }
+
+    export function mkIconButton(icon: string, width: number, height = width + BUTTON_BOTTOM_BORDER_WIDTH - BUTTON_BORDER_WIDTH) {
+        const g = drawSingleButton(width, height);
+        return new TextButton(g, icon, "sprite-editor-icon");
+    }
+
+    export function mkXIconButton(icon: string, width: number, height = width + BUTTON_BOTTOM_BORDER_WIDTH - BUTTON_BORDER_WIDTH) {
+        const g = drawSingleButton(width, height);
+        return new TextButton(g, icon, "sprite-editor-xicon");
+    }
+
+    export function mkTextButton(text: string, width: number, height: number) {
+        const g = drawSingleButton(width, height);
+        const t = new TextButton(g, text, "sprite-editor-text");
+        t.addClass("sprite-editor-label");
+        return t;
+    }
+
+    /**
+     * Draws a button suitable for the left end of a button group.
+     *
+     * @param width The total width of the result (including border)
+     * @param height The total height of the resul (including border and lip)
+     * @param lip  The width of the bottom border
+     * @param border The width of the outer border (except bottom)
+     * @param r The corner radius
+     */
+    function drawLeftButton(width: number, height: number, lip: number, border: number, r: number): ButtonGroup {
+        const root = new svg.Group().appendClass("sprite-editor-button");
+        const bg = root.draw("path")
+            .appendClass("sprite-editor-button-bg");
+        bg.d.moveTo(r, 0)
+            .lineBy(width - r, 0)
+            .lineBy(0, height)
+            .lineBy(-(width - r), 0)
+            .arcBy(r, r, 0, false, true, -r, -r)
+            .lineBy(0, -(height - (r << 1)))
+            .arcBy(r, r, 0, false, true, r, -r)
+            .close();
+        bg.update();
+
+        const fg = root.draw("path")
+            .appendClass("sprite-editor-button-fg");
+        fg.d.moveTo(border + r, border)
+            .lineBy(width - border - r, 0)
+            .lineBy(0, height - lip - border)
+            .lineBy(-(width - border - r), 0)
+            .arcBy(r, r, 0, false, true, -r, -r)
+            .lineBy(0, -(height - lip - border - (r << 1)))
+            .arcBy(r, r, 0, false, true, r, -r)
+            .close();
+        fg.update();
+
+        return {
+            root,
+            cx: border + (width - border) / 2,
+            cy: border + (height - lip) / 2
+        };
+    }
+
+    export class CursorMultiButton {
+        root: svg.Group;
+        selected: number;
+        buttons: Button[];
+
+        indexHandler: (index: number) => void;
+
+        constructor(parent: svg.Group, width: number) {
+            this.root = parent.group();
+            const widths = [4, 7, 10]
+
+            this.buttons = buttonGroup(65, 21, 3).map((b, i) => new CursorButton(b.root, b.cx, b.cy, widths[i]));
+            this.buttons.forEach((button, index) => {
+                button.onClick(() => this.handleClick(index));
+                button.title(sizeAdjective(index));
+                this.root.appendChild(button.getElement());
+            });
+        }
+
+        protected handleClick(index: number) {
+            if (index === this.selected) return;
+
+            if (this.selected != undefined) {
+                this.buttons[this.selected].setSelected(false);
+            }
+
+            this.selected = index;
+
+            if (this.selected != undefined) {
+                this.buttons[this.selected].setSelected(true);
+            }
+
+            if (this.indexHandler) this.indexHandler(index);
+        }
+
+        onSelected(cb: (index: number) => void) {
+            this.indexHandler = cb;
+        }
+    }
+
+    export interface UndoRedoHost {
+        undo(): void;
+        redo(): void;
+    }
+
+    export class UndoRedoGroup {
+        root: svg.Group;
+        undo: TextButton;
+        redo: TextButton;
+
+        host: UndoRedoHost;
+
+        constructor(parent: svg.Group, host: UndoRedoHost, width: number, height: number) {
+            this.root = parent.group();
+            this.host = host;
+            const [undo, redo] = buttonGroup(width, height, 2);
+
+            this.undo = new TextButton(undo, "\uf118", "sprite-editor-xicon");
+            this.undo.onClick(() => this.host.undo());
+            this.root.appendChild(this.undo.getElement());
+
+
+            this.redo = new TextButton(redo, "\uf111", "sprite-editor-xicon");
+            this.redo.onClick(() => this.host.redo());
+            this.root.appendChild(this.redo.getElement());
+        }
+
+        translate(x: number, y: number) {
+            this.root.translate(x, y);
+        }
+
+        updateState(undo: boolean, redo: boolean) {
+            this.undo.setDisabled(undo);
+            this.redo.setDisabled(redo);
+        }
+    }
+
+
+    function defaultColors(props: Partial<ToggleProps>): ToggleProps {
+        if (!props.baseColor) props.baseColor = "#e95153";
+        if (!props.backgroundColor) props.backgroundColor = "rgba(52,73,94,.2)";
+        if (!props.borderColor) props.borderColor = "rgba(52,73,94,.4)";
+        if (!props.selectedTextColor) props.selectedTextColor = props.baseColor;
+        if (!props.unselectedTextColor) props.unselectedTextColor = "hsla(0,0%,100%,.9)";
+        if (!props.switchColor) props.switchColor = "#ffffff";
+
+        return props as ToggleProps;
+    }
+
+    function sizeAdjective(cursorIndex: number) {
+        switch (cursorIndex) {
+            case 0: return lf("Small Cursor");
+            case 1: return lf("Medium Cursor");
+            case 2: return lf("Large Cursor");
+        }
+
+        return undefined;
+    }
+
+        /**
+     * Draws a button suitable for the interior of a button group.
+     *
+     * @param width The total width of the result (including border)
+     * @param height The total height of the resul (including border and lip)
+     * @param lip  The width of the bottom border
+     * @param border The width of the outer border (except bottom)
+     */
+    function drawMidButton(width: number, height: number, lip: number, border: number): ButtonGroup {
+        const root = new svg.Group().appendClass("sprite-editor-button");
+        const bg = root.draw("rect")
+            .appendClass("sprite-editor-button-bg")
+            .size(width, height)
+
+        const fg = root.draw("rect")
+            .appendClass("sprite-editor-button-fg")
+            .size(width - border, height - lip - border)
+            .at(border, border);
+
+        return {
+            root,
+            cx: border + (width - border) / 2,
+            cy: border + (height - lip) / 2
+        };
+    }
+
+    /**
+     * Draws a button suitable for the right end of a button group.
+     *
+     * @param width The total width of the result (including border)
+     * @param height The total height of the resul (including border and lip)
+     * @param lip  The width of the bottom border
+     * @param border The width of the outer border (except bottom)
+     * @param r The corner radius
+     */
+    function drawRightButton(width: number, height: number, lip: number, border: number, r: number): ButtonGroup {
+        const root = new svg.Group().appendClass("sprite-editor-button");
+        const bg = root.draw("path")
+            .appendClass("sprite-editor-button-bg");
+        bg.d.moveTo(0, 0)
+            .lineBy(width - r, 0)
+            .arcBy(r, r, 0, false, true, r, r)
+            .lineBy(0, height - (r << 1))
+            .arcBy(r, r, 0, false, true, -r, r)
+            .lineBy(-(width - r), 0)
+            .lineBy(0, -height)
+            .close();
+        bg.update();
+
+        const fg = root.draw("path")
+            .appendClass("sprite-editor-button-fg");
+        fg.d.moveTo(border, border)
+            .lineBy(width - border - r, 0)
+            .arcBy(r, r, 0, false, true, r, r)
+            .lineBy(0, height - border - lip - (r << 1))
+            .arcBy(r, r, 0, false, true, -r, r)
+            .lineBy(-(width - border - r), 0)
+            .lineBy(0, -(height - border - lip))
+            .close();
+        fg.update();
+
+        const content = root.group().id("sprite-editor-button-content");
+        content.translate(border + (width - (border << 1)) >> 1, (height - lip - border) >> 1);
+
+        return {
+            root,
+            cx: width / 2,
+            cy: border + (height - lip) / 2
+        };
+    }
+
+    /**
+     * Draws a standalone button.
+     *
+     * @param width The total width of the result (including border)
+     * @param height The total height of the resul (including border and lip)
+     * @param lip  The width of the bottom border
+     * @param border The width of the outer border (except bottom)
+     * @param r The corner radius
+     */
+    function drawSingleButton(width: number, height: number, lip = BUTTON_BOTTOM_BORDER_WIDTH, border = BUTTON_BORDER_WIDTH, r = BUTTON_CORNER_RADIUS): ButtonGroup {
+        const root = new svg.Group().appendClass("sprite-editor-button");
+        root.draw("rect")
+            .size(width, height)
+            .corners(r, r)
+            .appendClass("sprite-editor-button-bg");
+
+        root.draw("rect")
+            .at(border, border)
+            .size(width - (border << 1), height - lip - border)
+            .corners(r, r)
+            .appendClass("sprite-editor-button-fg");
+
+        return {
+            root,
+            cx: width / 2,
+            cy: border + (height - lip) / 2
+        };
+    }
+
+    function buttonGroup(width: number, height: number, segments: number, lip = BUTTON_BOTTOM_BORDER_WIDTH, border = BUTTON_BORDER_WIDTH, r = BUTTON_CORNER_RADIUS): ButtonGroup[] {
+        const available = width - (segments + 1) * border;
+        const segmentWidth = Math.floor(available / segments);
+
+        const result: ButtonGroup[] = [];
+        for (let i = 0; i < segments; i++) {
+            if (i === 0) {
+                result.push(drawLeftButton(segmentWidth + border, height, lip, border, r));
+            }
+            else if (i === segments - 1) {
+                const b = drawRightButton(segmentWidth + (border << 1), height, lip, border, r);
+                b.root.translate((border + segmentWidth) * i, 0);
+                result.push(b);
+            }
+            else {
+                const b = drawMidButton(segmentWidth + border, height, lip, border);
+                b.root.translate((border + segmentWidth) * i, 0);
+                result.push(b);
+            }
+        }
+
+        return result;
+    }
+
+    export function mkText(text: string) {
+        return new svg.Text(text)
+            .anchor("middle")
+            .setAttribute("dominant-baseline", "middle")
+            .setAttribute("dy", (pxt.BrowserUtils.isIE() || pxt.BrowserUtils.isEdge()) ? "0.3em" : "0.1em")
+    }
+}

--- a/pxtlib/round-matrix-editor/canvasGrid.ts
+++ b/pxtlib/round-matrix-editor/canvasGrid.ts
@@ -1,0 +1,635 @@
+namespace pxtmatrix {
+    const alphaCellWidth = 5;
+    const dropdownPaddding = 4;
+    const lightModeBackground = "#dedede";
+
+    export class CanvasGrid {
+        protected cellWidth: number = 16;
+        protected cellHeight: number = 16;
+
+        private gesture: GestureState;
+        private context: CanvasRenderingContext2D;
+        private fadeAnimation: Fade;
+        private selectAnimation: number;
+
+        protected backgroundLayer: HTMLCanvasElement;
+        protected paintLayer: HTMLCanvasElement;
+        protected overlayLayer: HTMLCanvasElement;
+
+        mouseCol: number;
+        mouseRow: number;
+
+        constructor(protected palette: string[], public state: CanvasState, protected lightMode = false) {
+            this.paintLayer = document.createElement("canvas");
+            this.paintLayer.setAttribute("class", "sprite-editor-canvas");
+            this.overlayLayer = document.createElement("canvas")
+            this.overlayLayer.setAttribute("class", "sprite-editor-canvas")
+
+            if (!this.lightMode) {
+                this.backgroundLayer = document.createElement("canvas");
+                this.backgroundLayer.setAttribute("class", "sprite-editor-canvas")
+                this.context = this.paintLayer.getContext("2d");
+            }
+            else {
+                this.context = this.paintLayer.getContext("2d", { alpha: false });
+                this.context.fillStyle = lightModeBackground;
+                this.context.fill();
+            }
+
+            this.hideOverlay();
+        }
+
+
+        get image() {
+            return this.state.image;
+        }
+
+        setEyedropperMouse(on: boolean) {
+            const eyedropperClass = "sprite-editor-eyedropper";
+
+            const toApply = on ? pxt.BrowserUtils.addClass : pxt.BrowserUtils.removeClass;
+            toApply(this.paintLayer, eyedropperClass);
+            toApply(this.overlayLayer, eyedropperClass);
+            if (!this.lightMode) {
+                toApply(this.backgroundLayer, eyedropperClass);
+            }
+        }
+
+        repaint(): void {
+            this.clearContext(this.context);
+            this.drawImage();
+            if (this.state.floatingLayer) this.drawFloatingLayer();
+            else this.hideOverlay();
+        }
+
+        applyEdit(edit: Edit, cursorCol: number, cursorRow: number, gestureEnd = false) {
+            edit.doEdit(this.state);
+            this.drawCursor(edit, cursorCol, cursorRow);
+        }
+
+        drawCursor(edit: Edit, col: number, row: number) {
+            const cursor = edit.getCursor();
+
+            if (cursor) {
+                this.repaint();
+                if (edit.showPreview) {
+                    edit.drawCursor(col, row, (c, r) => {
+                        this.drawColor(c, r, edit.color);
+                    });
+                }
+                this.context.strokeStyle = "#898989";
+                this.context.strokeRect((col + cursor.offsetX) * this.cellWidth, (row + cursor.offsetY) * this.cellHeight, cursor.width * this.cellWidth, cursor.height * this.cellHeight);
+            }
+            else if (edit.isStarted) {
+                this.repaint();
+            }
+        }
+
+        bitmap() {
+            return this.image;
+        }
+
+        outerWidth(): number {
+            return this.paintLayer.getBoundingClientRect().width;
+        }
+
+        outerHeight(): number {
+            return this.paintLayer.getBoundingClientRect().height;
+        }
+
+        writeColor(col: number, row: number, color: number) {
+            this.image.set(col, row, color);
+            this.drawColor(col, row, color);
+        }
+
+        drawColor(col: number, row: number, color: number, context = this.context, transparency = !this.lightMode) {
+            const x = col * this.cellWidth;
+            const y = row * this.cellHeight;
+
+            if (color) {
+                context.fillStyle = this.palette[color - 1];
+                context.fillRect(x, y, this.cellWidth, this.cellHeight);
+            }
+            else if (!transparency) {
+                context.fillStyle = lightModeBackground;
+                context.fillRect(x, y, this.cellWidth, this.cellHeight);
+            }
+        }
+
+        restore(state: CanvasState, repaint = false) {
+            if (state.height != this.image.height || state.width != this.image.width) {
+                this.state = state.copy();
+                this.resizeGrid(state.width, state.width * state.height);
+            }
+            else {
+                this.state = state.copy();
+            }
+
+            if (repaint) {
+                this.repaint();
+            }
+        }
+
+        showResizeOverlay(): void {
+            if (this.lightMode) return;
+
+            if (this.fadeAnimation) {
+                this.fadeAnimation.kill();
+            }
+            this.showOverlay();
+            this.stopSelectAnimation();
+
+            const w = this.overlayLayer.width;
+            const h = this.overlayLayer.height;
+            const context = this.overlayLayer.getContext("2d");
+            const toastWidth = 100;
+            const toastHeight = 40;
+            const toastLeft = w / 2 - toastWidth / 2;
+            const toastTop = h / 2 - toastWidth / 4;
+
+            this.fadeAnimation = new Fade((opacity, dead) => {
+                if (dead) {
+                    this.drawFloatingLayer();
+                    return;
+                }
+
+                this.clearContext(context);
+                context.globalAlpha = opacity;
+                context.fillStyle = "#898989";
+
+                // After 32x32 the grid isn't easy to see anymore so skip it
+                if (this.image.width <= 32 && this.image.height <= 32) {
+                    for (let c = 1; c < this.image.width; c++) {
+                        context.fillRect(c * this.cellWidth, 0, 1, h);
+                    }
+                    for (let r = 1; r < this.image.height; r++) {
+                        context.fillRect(0, r * this.cellHeight, w, 1);
+                    }
+                }
+
+                context.fillRect(toastLeft, toastTop, toastWidth, toastHeight);
+                context.fillStyle = "#ffffff";
+                context.font = "30px sans-serif";
+                context.textBaseline = "middle";
+                context.textAlign = "center";
+
+                context.fillText(this.image.width.toString(), toastLeft + toastWidth / 2 - 25, toastTop  + toastHeight / 2);
+                context.fillText("x", toastLeft + 50, toastTop + toastHeight / 2, 10);
+                context.fillText(this.image.height.toString(), toastLeft + toastWidth / 2 + 25, toastTop + toastHeight / 2);
+            }, 750, 500);
+        }
+
+        showOverlay() {
+            this.overlayLayer.style.visibility = "visible";
+        }
+
+        hideOverlay() {
+            this.stopSelectAnimation();
+
+            this.overlayLayer.style.visibility = "hidden";
+
+            if (this.fadeAnimation) {
+                this.fadeAnimation.kill();
+            }
+        }
+
+        resizeGrid(rowLength: number, numCells: number): void {
+            this.repaint();
+        }
+
+        setCellDimensions(width: number, height: number): void {
+            this.cellWidth = width | 0;
+            this.cellHeight = height | 0;
+
+            const canvasWidth = this.cellWidth * this.image.width;
+            const canvasHeight = this.cellHeight * this.image.height;
+
+            this.paintLayer.width = canvasWidth;
+            this.paintLayer.height = canvasHeight;
+            this.overlayLayer.width = canvasWidth;
+            this.overlayLayer.height = canvasHeight;
+
+            if (!this.lightMode) {
+                this.backgroundLayer.width = canvasWidth;
+                this.backgroundLayer.height = canvasHeight;
+            }
+        }
+
+        setGridDimensions(width: number, height = width, lockAspectRatio = true): void {
+            const maxCellWidth = width / this.image.width;
+            const maxCellHeight = height / this.image.height;
+
+            if (lockAspectRatio) {
+                const aspectRatio = this.cellWidth / this.cellHeight;
+
+                if (aspectRatio >= 1) {
+                    const w = Math.min(maxCellWidth, maxCellHeight * aspectRatio);
+                    this.setCellDimensions(w, w * aspectRatio);
+                }
+                else {
+                    const h = Math.min(maxCellHeight, maxCellWidth / aspectRatio)
+                    this.setCellDimensions(h / aspectRatio, h);
+                }
+            }
+            else {
+                this.setCellDimensions(maxCellWidth, maxCellHeight);
+            }
+        }
+
+        down(handler: (col: number, row: number) => void): void {
+            this.initDragSurface();
+            this.gesture.subscribe(GestureType.Down, handler);
+        }
+
+        up(handler: (col: number, row: number) => void): void {
+            this.initDragSurface();
+            this.gesture.subscribe(GestureType.Up, handler);
+        }
+
+        drag(handler: (col: number, row: number) => void): void {
+            this.initDragSurface();
+            this.gesture.subscribe(GestureType.Drag, handler);
+        }
+
+        move(handler: (col: number, row: number) => void): void {
+            this.initDragSurface();
+            this.gesture.subscribe(GestureType.Move, handler);
+        }
+
+        leave(handler: () => void): void {
+            this.initDragSurface();
+            this.gesture.subscribe(GestureType.Leave, handler);
+        }
+
+        updateBounds(top: number, left: number, width: number, height: number) {
+            this.layoutCanvas(this.paintLayer, top, left, width, height);
+            this.layoutCanvas(this.overlayLayer, top, left, width, height);
+
+            if (!this.lightMode) {
+                this.layoutCanvas(this.backgroundLayer, top, left, width, height);
+            }
+
+            this.drawImage();
+            this.drawBackground();
+        }
+
+        render(parent: HTMLDivElement) {
+            if (!this.lightMode) {
+                parent.appendChild(this.backgroundLayer);
+            }
+
+            parent.appendChild(this.paintLayer);
+            parent.appendChild(this.overlayLayer);
+        }
+
+        removeMouseListeners() {
+            this.stopSelectAnimation();
+            if (this.fadeAnimation) this.fadeAnimation.kill();
+
+            this.endDrag();
+        }
+
+        onEditStart(col: number, row: number, edit: Edit) {
+            edit.start(col, row, this.state);
+        }
+
+        onEditEnd(col: number, row: number, edit: Edit) {
+            edit.end(col, row, this.state);
+            this.drawFloatingLayer();
+        }
+
+        protected drawImage(image = this.image, context = this.context, left = 0, top = 0, transparency = !this.lightMode) {
+            for (let c = 0; c < image.width; c++) {
+                for (let r = 0; r < image.height; r++) {
+                    this.drawColor(left + c, top + r, image.get(c, r), context, transparency);
+                }
+            }
+        }
+
+        protected drawBackground() {
+            if (this.lightMode) return;
+            const context = this.backgroundLayer.getContext("2d", { alpha: false });
+            const alphaCols = Math.ceil(this.paintLayer.width / alphaCellWidth);
+            const alphaRows = Math.ceil(this.paintLayer.height / alphaCellWidth);
+            context.fillStyle = "#ffffff";
+            context.fillRect(0, 0, this.paintLayer.width, this.paintLayer.height);
+
+            context.fillStyle = "#dedede";
+            for (let ac = 0; ac < alphaCols; ac++) {
+                for (let ar = 0; ar < alphaRows; ar++) {
+                    if ((ac + ar) % 2) {
+                        context.fillRect(ac * alphaCellWidth, ar * alphaCellWidth, alphaCellWidth, alphaCellWidth);
+                    }
+                }
+            }
+        }
+
+        /**
+         * This calls getBoundingClientRect() so don't call it in a loop!
+         */
+        protected clientEventToCell(ev: MouseEvent) {
+            const coord = clientCoord(ev);
+            const bounds = this.paintLayer.getBoundingClientRect();
+            const left = bounds.left + (window.scrollX !== null ? window.scrollX : window.pageXOffset);
+            const top = bounds.top + (window.scrollY !== null ? window.scrollY : window.pageYOffset);
+
+            this.mouseCol = Math.floor((coord.clientX - left) / this.cellWidth);
+            this.mouseRow = Math.floor((coord.clientY - top) / this.cellHeight);
+
+            return [
+                this.mouseCol,
+                this.mouseRow
+            ];
+        }
+        protected drawFloatingLayer() {
+            if (!this.state.floatingLayer) {
+                return;
+            }
+            this.drawImage(this.state.floatingLayer, this.context, this.state.layerOffsetX, this.state.layerOffsetY, true);
+
+            this.drawSelectionAnimation();
+        }
+
+        protected drawSelectionAnimation(dashOffset = 0) {
+            if (!this.state.floatingLayer) {
+                this.hideOverlay();
+                return;
+            }
+            this.showOverlay();
+            const context = this.overlayLayer.getContext("2d");
+            this.clearContext(context);
+            context.globalAlpha = 1;
+            context.strokeStyle = "#303030";
+            context.lineWidth = 2;
+            context.setLineDash([5, 3]);
+            context.lineDashOffset = dashOffset;
+            context.strokeRect(this.state.layerOffsetX * this.cellWidth, this.state.layerOffsetY * this.cellHeight, this.state.floatingLayer.width * this.cellWidth, this.state.floatingLayer.height * this.cellHeight);
+
+
+            if (!this.lightMode && !this.selectAnimation && (!this.fadeAnimation || this.fadeAnimation.dead)) {
+                let drawLayer = () => {
+                    dashOffset++
+                    requestAnimationFrame(() => this.drawSelectionAnimation(dashOffset));
+                };
+
+                this.selectAnimation = setInterval(drawLayer, 40)
+            }
+        }
+
+        private clearContext(context: CanvasRenderingContext2D) {
+            // Paint Layer has the same dimensions as all other contexts
+            context.clearRect(0, 0, this.paintLayer.width, this.paintLayer.height);
+        }
+
+        private initDragSurface() {
+            if (!this.gesture) {
+                this.gesture = new GestureState();
+
+                this.bindEvents(this.paintLayer);
+                this.bindEvents(this.overlayLayer);
+
+                document.addEventListener(pxt.BrowserUtils.pointerEvents.move, this.hoverHandler);
+            }
+        }
+
+        private bindEvents(surface: HTMLElement) {
+            pxt.BrowserUtils.pointerEvents.down.forEach(evId => {
+                surface.addEventListener(evId, (ev: MouseEvent) => {
+                    this.startDrag();
+                    const [col, row] = this.clientEventToCell(ev);
+                    this.gesture.handle(InputEvent.Down, col, row);
+                });
+            })
+
+            // surface.addEventListener("click", (ev: MouseEvent) => {
+            //     const [col, row] = this.clientEventToCell(ev);
+            //     this.gesture.handle(InputEvent.Down, col, row);
+            //     this.gesture.handle(InputEvent.Up, col, row);
+            // });
+        }
+
+        private upHandler = (ev: MouseEvent) => {
+            this.endDrag();
+            const [col, row] = this.clientEventToCell(ev);
+            this.gesture.handle(InputEvent.Up, col, row);
+
+            ev.stopPropagation();
+            ev.preventDefault();
+        }
+
+        private leaveHandler = (ev: MouseEvent) => {
+            this.endDrag();
+            const [col, row] = this.clientEventToCell(ev);
+            this.gesture.handle(InputEvent.Leave, col, row);
+
+            ev.stopPropagation();
+            ev.preventDefault();
+        };
+
+        private moveHandler = (ev: MouseEvent) => {
+            const [col, row] = this.clientEventToCell(ev);
+            if (col >= 0 && row >= 0 && col < this.image.width && row < this.image.height) {
+                if (ev.buttons & 1) {
+                    this.gesture.handle(InputEvent.Down, col, row);
+                }
+                this.gesture.handle(InputEvent.Move, col, row);
+            }
+
+            ev.stopPropagation();
+            ev.preventDefault();
+        }
+
+        private hoverHandler = (ev: MouseEvent) => {
+            const [col, row] = this.clientEventToCell(ev);
+            if (col >= 0 && row >= 0 && col < this.image.width && row < this.image.height) {
+                this.gesture.handle(InputEvent.Move, col, row);
+                this.gesture.isHover = true;
+            }
+            else if (this.gesture.isHover) {
+                this.gesture.isHover = false;
+                this.gesture.handle(InputEvent.Leave, -1, -1);
+            }
+        }
+
+        private startDrag() {
+            document.removeEventListener(pxt.BrowserUtils.pointerEvents.move, this.hoverHandler);
+            document.addEventListener(pxt.BrowserUtils.pointerEvents.move, this.moveHandler);
+            document.addEventListener(pxt.BrowserUtils.pointerEvents.up, this.upHandler);
+
+            if (pxt.BrowserUtils.isTouchEnabled() && !pxt.BrowserUtils.hasPointerEvents()) {
+                document.addEventListener("touchend", this.upHandler);
+                document.addEventListener("touchcancel", this.leaveHandler);
+            }
+            else {
+                document.addEventListener(pxt.BrowserUtils.pointerEvents.leave, this.leaveHandler);
+            }
+        }
+
+        private endDrag() {
+            document.addEventListener(pxt.BrowserUtils.pointerEvents.move, this.hoverHandler);
+            document.removeEventListener(pxt.BrowserUtils.pointerEvents.move, this.moveHandler);
+            document.removeEventListener(pxt.BrowserUtils.pointerEvents.up, this.upHandler);
+            document.removeEventListener(pxt.BrowserUtils.pointerEvents.leave, this.leaveHandler);
+
+            if (pxt.BrowserUtils.isTouchEnabled() && !pxt.BrowserUtils.hasPointerEvents()) {
+                document.removeEventListener("touchend", this.upHandler);
+                document.removeEventListener("touchcancel", this.leaveHandler);
+            }
+            else {
+                document.removeEventListener(pxt.BrowserUtils.pointerEvents.leave, this.leaveHandler);
+            }
+        }
+
+        private layoutCanvas(canvas: HTMLCanvasElement, top: number, left: number, width: number, height: number) {
+            canvas.style.position = "absolute";
+
+            if (this.image.width === this.image.height) {
+                canvas.style.top = top + "px";
+                canvas.style.left = left + "px";
+            }
+            else if (this.image.width > this.image.height) {
+                canvas.style.top = (top + dropdownPaddding + (height - canvas.height) / 2) + "px";
+                canvas.style.left = left + "px";
+            }
+            else {
+                canvas.style.top = top + "px";
+                canvas.style.left = (left + dropdownPaddding + (width - canvas.width) / 2) + "px";
+            }
+        }
+
+        private stopSelectAnimation() {
+            if (this.selectAnimation) {
+                clearInterval(this.selectAnimation);
+                this.selectAnimation = undefined;
+            }
+
+        }
+    }
+
+    enum InputEvent {
+        Up,
+        Down,
+        Move,
+        Leave
+    }
+
+    enum GestureType {
+        Up,
+        Down,
+        Move,
+        Drag,
+        Leave
+    }
+
+    type GestureHandler = (col: number, row: number) => void;
+
+    class GestureState {
+        lastCol: number;
+        lastRow: number;
+
+        isDown = false;
+        isHover = false;
+
+        handlers: {[index: number]: GestureHandler} = {};
+
+        handle(event: InputEvent, col: number, row: number) {
+            switch (event) {
+                case InputEvent.Up:
+                    this.update(col, row);
+                    this.isDown = false;
+                    this.fire(GestureType.Up);
+                    break;
+                case InputEvent.Down:
+                    if (!this.isDown) {
+                        this.update(col, row);
+                        this.isDown = true;
+                        this.fire(GestureType.Down);
+                    }
+                    break;
+                case InputEvent.Move:
+                    if (col === this.lastCol && row === this.lastRow) return;
+                    this.update(col, row);
+                    if (this.isDown) {
+                        this.fire(GestureType.Drag);
+                    }
+                    else {
+                        this.fire(GestureType.Move);
+                    }
+                    break;
+
+                case InputEvent.Leave:
+                    this.update(col, row);
+                    this.isDown = false;
+                    this.fire(GestureType.Leave);
+                    break;
+            }
+        }
+
+        subscribe(type: GestureType, handler: GestureHandler) {
+            this.handlers[type] = handler;
+        }
+
+        protected update(col: number, row: number) {
+            this.lastCol = col;
+            this.lastRow = row;
+        }
+
+        protected fire(type: GestureType) {
+            if (this.handlers[type]) {
+                this.handlers[type](this.lastCol, this.lastRow);
+            }
+        }
+    }
+
+    class Fade {
+        start: number;
+        end: number;
+        slope: number;
+        dead: boolean;
+
+        constructor (protected draw: (opacity: number, dead: boolean) => void, delay: number, duration: number) {
+            this.start = Date.now() + delay;
+            this.end = this.start + duration;
+            this.slope = 1 / duration;
+            this.dead = false;
+
+            draw(1, false);
+
+            setTimeout(() => requestAnimationFrame(() => this.frame()), delay);
+        }
+
+        frame() {
+            if (this.dead) return;
+            const now = Date.now();
+            if (now < this.end) {
+                const v = 1 - (this.slope * (now - this.start));
+                this.draw(v, false);
+                requestAnimationFrame(() => this.frame());
+            }
+            else {
+                this.kill();
+                this.draw(0, true);
+            }
+        }
+
+        kill() {
+            this.dead = true;
+        }
+    }
+
+    export interface ClientCoordinates {
+        clientX: number;
+        clientY: number;
+    }
+
+    function clientCoord(ev: PointerEvent | MouseEvent | TouchEvent): ClientCoordinates {
+        if ((ev as TouchEvent).touches) {
+            const te = ev as TouchEvent;
+            if (te.touches.length) {
+                return te.touches[0];
+            }
+            return te.changedTouches[0];
+        }
+        return (ev as PointerEvent | MouseEvent);
+    }
+}

--- a/pxtlib/round-matrix-editor/canvasState.ts
+++ b/pxtlib/round-matrix-editor/canvasState.ts
@@ -1,0 +1,90 @@
+namespace pxtmatrix {
+    export class CanvasState {
+        image: Bitmap;
+        floatingLayer: Bitmap;
+        layerOffsetX: number;
+        layerOffsetY: number;
+
+        constructor(bitmap?: Bitmap) {
+            this.image = bitmap;
+            this.layerOffsetX = 0;
+            this.layerOffsetY = 0;
+        }
+
+        get width() {
+            return this.image.width;
+        }
+
+        get height() {
+            return this.image.height;
+        }
+
+        copy() {
+            const res = new CanvasState();
+            res.image = this.image.copy();
+
+            if (this.floatingLayer) {
+                res.floatingLayer = this.floatingLayer.copy();
+                res.floatingLayer.x0 = this.layerOffsetX;
+                res.floatingLayer.y0 = this.layerOffsetY;
+            }
+            res.layerOffsetX = this.layerOffsetX;
+            res.layerOffsetY = this.layerOffsetY;
+
+            return res;
+        }
+
+        equals(other: CanvasState) {
+            if (!this.image.equals(other.image) || (this.floatingLayer && !other.floatingLayer) || (!this.floatingLayer && other.floatingLayer)) return false;
+
+            if (this.floatingLayer) return this.floatingLayer.equals(other.floatingLayer) && this.layerOffsetX === other.layerOffsetX && this.layerOffsetY === other.layerOffsetY;
+
+            return true;
+        }
+
+        mergeFloatingLayer() {
+            if (!this.floatingLayer) return;
+
+            this.floatingLayer.x0 = this.layerOffsetX;
+            this.floatingLayer.y0 = this.layerOffsetY;
+
+            this.image.apply(this.floatingLayer, true);
+            this.floatingLayer = undefined;
+        }
+
+        copyToLayer(left: number, top: number, width: number, height: number, cut = false) {
+            if (width === 0 || height === 0) return;
+
+            if (width < 0) {
+                left += width;
+                width = -width;
+            }
+
+            if (height < 0) {
+                top += height;
+                height = -height;
+            }
+
+            this.floatingLayer = this.image.copy(left, top, width, height);
+            this.layerOffsetX = this.floatingLayer.x0;
+            this.layerOffsetY = this.floatingLayer.y0;
+
+            if (cut) {
+                for (let c = 0; c < width; c++) {
+                    for (let r = 0; r < height; r++) {
+                        this.image.set(left + c, top + r, 0);
+                    }
+                }
+            }
+        }
+
+        inFloatingLayer(col: number, row: number) {
+            if (!this.floatingLayer) return false;
+
+            col = col - this.layerOffsetX;
+            row = row - this.layerOffsetY;
+
+            return col >= 0 && col < this.floatingLayer.width && row >= 0 && row < this.floatingLayer.height;
+        }
+    }
+}

--- a/pxtlib/round-matrix-editor/gallery.ts
+++ b/pxtlib/round-matrix-editor/gallery.ts
@@ -1,0 +1,256 @@
+namespace pxtmatrix {
+    export interface GalleryItem {
+        qName: string;
+        src: string;
+        alt: string;
+    }
+
+    const COLUMNS = 4;
+
+    export class Gallery {
+        protected info: pxtc.BlocksInfo;
+        protected contentDiv: HTMLDivElement;
+        protected containerDiv: HTMLDivElement;
+
+        protected itemBorderColor: string;
+        protected itemBackgroundColor: string;
+
+        protected visible = false;
+
+        protected pending: (res: Bitmap, err?: string) => void;
+
+        constructor(info: pxtc.BlocksInfo) {
+            this.info = info;
+
+            this.containerDiv = document.createElement("div");
+            this.containerDiv.setAttribute("id", "sprite-editor-gallery-outer");
+            this.contentDiv = document.createElement("div");
+            this.contentDiv.setAttribute("id", "sprite-editor-gallery");
+
+            this.itemBackgroundColor = "#ffffff";
+            this.itemBorderColor = "#000000";
+
+            this.initStyles();
+            this.containerDiv.appendChild(this.contentDiv);
+
+            this.containerDiv.style.display = "none";
+            this.contentDiv.addEventListener("animationend", () => {
+                if (!this.visible) {
+                    this.containerDiv.style.display = "none";
+                }
+            });
+
+            this.contentDiv.addEventListener('wheel', e => {
+                e.stopPropagation();
+            }, true)
+        }
+
+        getElement() {
+            return this.containerDiv;
+        }
+
+        show(cb: (res: Bitmap, err?: string) => void) {
+            if (this.pending) {
+                this.reject("Error: multiple calls");
+            }
+            this.pending = cb;
+
+            this.containerDiv.style.display = "block";
+            this.buildDom();
+            this.visible = true;
+            this.contentDiv.setAttribute("class", "shown");
+        }
+
+        hide() {
+            if (this.pending) {
+                this.reject("cancelled");
+            }
+            this.visible = false;
+            this.contentDiv.setAttribute("class", "hidden-above");
+        }
+
+        layout(left: number, top: number, height: number) {
+            this.containerDiv.style.left = left + "px";
+            this.containerDiv.style.top = top + "px";
+            this.containerDiv.style.height = height + "px";
+        }
+
+        protected buildDom() {
+            while (this.contentDiv.firstChild) this.contentDiv.removeChild(this.contentDiv.firstChild);
+            const totalWidth = this.containerDiv.clientWidth - 17;
+            const buttonWidth = (Math.floor(totalWidth / COLUMNS) - 8) + "px";
+            this.getGalleryItems("Image").forEach((item, i) => this.mkButton(item.src, item.alt, item.qName, i, buttonWidth));
+        }
+
+        protected initStyles() {
+            const style = document.createElement("style");
+            style.textContent = `
+            #sprite-editor-gallery {
+                margin-top: -100%;
+            }
+
+            #sprite-editor-gallery.hidden-above {
+                margin-top: -100%;
+                animation: slide-up 0.2s 0s ease;
+            }
+
+            #sprite-editor-gallery.shown {
+                margin-top: 0px;
+                animation: slide-down 0.2s 0s ease;
+            }
+
+            @keyframes slide-down {
+                0% {
+                    margin-top: -100%;
+                }
+                100% {
+                    margin-top: 0px;
+                }
+            }
+
+            @keyframes slide-up {
+                0% {
+                    margin-top: 0px;
+                }
+                100% {
+                    margin-top: -100%;
+                }
+            }
+            `;
+            this.containerDiv.appendChild(style);
+        }
+
+        protected mkButton(src: string, alt: string, value: string, i: number, width: string) {
+            let button = document.createElement('button');
+            button.setAttribute('id', ':' + i); // For aria-activedescendant
+            button.setAttribute('role', 'menuitem');
+            button.setAttribute('class', 'sprite-gallery-button sprite-editor-card');
+            button.title = alt;
+            button.style.width = width;
+            button.style.height = width;
+            let backgroundColor = this.itemBackgroundColor;
+
+            button.style.backgroundColor = backgroundColor;
+            button.style.borderColor = this.itemBorderColor;
+
+            const parentDiv = this.contentDiv;
+
+            button.addEventListener("click", () => this.handleSelection(value));
+            button.addEventListener(pxt.BrowserUtils.pointerEvents.move, () => {
+                button.setAttribute('class', 'sprite-gallery-button sprite-gallery-button-hover sprite-editor-card');
+                parentDiv.setAttribute('aria-activedescendant', button.id);
+            });
+            button.addEventListener(pxt.BrowserUtils.pointerEvents.leave, () => {
+                button.setAttribute('class', 'sprite-gallery-button sprite-editor-card');
+                parentDiv.removeAttribute('aria-activedescendant');
+            });
+
+            let buttonImg = document.createElement('img');
+            buttonImg.src = src;
+            button.setAttribute('data-value', value);
+            buttonImg.setAttribute('data-value', value);
+            button.appendChild(buttonImg);
+            this.contentDiv.appendChild(button);
+        }
+
+        protected resolve(bitmap: Bitmap) {
+            if (this.pending) {
+                const cb = this.pending;
+                this.pending = undefined;
+                cb(bitmap);
+            }
+        }
+
+        protected reject(reason: string) {
+            if (this.pending) {
+                const cb = this.pending;
+                this.pending = undefined;
+                cb(undefined, reason);
+            }
+        }
+
+        protected handleSelection(value: string) {
+            this.resolve(this.getBitmap(value));
+        }
+
+        protected getBitmap(qName: string) {
+            const sym = this.info.apis.byQName[qName];
+            const jresURL = sym.attributes.jresURL;
+            const data = atob(jresURL.slice(jresURL.indexOf(",") + 1))
+            const magic = data.charCodeAt(0);
+            const w = data.charCodeAt(1);
+            const h = data.charCodeAt(2);
+
+            const out = new Bitmap(w, h);
+
+            let index = 4
+            if (magic === 0xe1) {
+                // Monochrome
+                let mask = 0x01
+                let v = data.charCodeAt(index++)
+                for (let x = 0; x < w; ++x) {
+                    for (let y = 0; y < h; ++y) {
+                        out.set(x, y, (v & mask) ? 1 : 0);
+                        mask <<= 1
+                        if (mask == 0x100) {
+                            mask = 0x01
+                            v = data.charCodeAt(index++)
+                        }
+                    }
+                }
+            }
+            else {
+                // Color
+                for (let x = 0; x < w; x++) {
+                    for (let y = 0; y < h; y += 2) {
+                        let v = data.charCodeAt(index++)
+                        out.set(x, y, v & 0xf);
+                        if (y != h - 1) {
+                            out.set(x, y + 1, (v >> 4) & 0xf);
+                        }
+                    }
+                    while (index & 3) index++
+                }
+            }
+
+            return out;
+        }
+
+
+        protected getGalleryItems(qName: string): GalleryItem[] {
+            const syms = getFixedInstanceDropdownValues(this.info.apis, qName);
+            generateIcons(syms);
+
+            return syms.map(sym => {
+                return {
+                    qName: sym.qName,
+                    src: sym.attributes.iconURL,
+                    alt: sym.qName
+                };
+            });
+        }
+    }
+
+    function getFixedInstanceDropdownValues(apis: pxtc.ApisInfo, qName: string) {
+        return pxt.Util.values(apis.byQName).filter(sym => sym.kind === pxtc.SymbolKind.Variable
+            && sym.attributes.fixedInstance
+            && isSubtype(apis, sym.retType, qName));
+    }
+
+    function isSubtype(apis: pxtc.ApisInfo, specific: string, general: string) {
+        if (specific == general) return true
+        let inf = apis.byQName[specific]
+        if (inf && inf.extendsTypes)
+            return inf.extendsTypes.indexOf(general) >= 0
+        return false
+    }
+
+    function generateIcons(instanceSymbols: pxtc.SymbolInfo[]) {
+        const imgConv = new pxt.ImageConverter();
+        instanceSymbols.forEach(v => {
+            if (v.attributes.jresURL && !v.attributes.iconURL && v.attributes.jresURL.indexOf("data:image/x-mkcd-f") == 0) {
+                v.attributes.iconURL = imgConv.convert(v.attributes.jresURL)
+            }
+        });
+    }
+}

--- a/pxtlib/round-matrix-editor/header.ts
+++ b/pxtlib/round-matrix-editor/header.ts
@@ -1,0 +1,42 @@
+/// <reference path="./buttons.ts" />
+namespace pxtmatrix {
+    import svg = pxt.svgUtil;
+
+    export interface SpriteHeaderHost {
+        showGallery(): void;
+        hideGallery(): void;
+    }
+
+    export class SpriteHeader {
+        div: HTMLDivElement;
+        root: svg.SVG;
+        toggle: Toggle;
+        undoButton: Button;
+        redoButton: Button;
+
+        constructor(protected host: SpriteHeaderHost) {
+            this.div = document.createElement("div");
+            this.div.setAttribute("id", "sprite-editor-header");
+
+            this.root = new svg.SVG(this.div).id("sprite-editor-header-controls");
+            this.toggle = new Toggle(this.root, { leftText: "Editor", rightText: "Gallery", baseColor: "#4B7BEC" });
+            this.toggle.onStateChange(isLeft => {
+                if (isLeft) {
+                    this.host.hideGallery();
+                }
+                else {
+                    this.host.showGallery();
+                }
+            });
+        }
+
+        getElement() {
+            return this.div;
+        }
+
+        layout() {
+            this.toggle.layout();
+            this.toggle.translate((TOTAL_HEIGHT - this.toggle.width()) / 2, (HEADER_HEIGHT - this.toggle.height()) / 2);
+        }
+    }
+}

--- a/pxtlib/round-matrix-editor/reporterBar.ts
+++ b/pxtlib/round-matrix-editor/reporterBar.ts
@@ -1,0 +1,107 @@
+/// <reference path="./buttons.ts" />
+namespace pxtmatrix {
+    import svg = pxt.svgUtil;
+
+    const UNDO_REDO_WIDTH = 65;
+    const SIZE_BUTTON_WIDTH = 65;
+    const SIZE_CURSOR_MARGIN = 10;
+
+    export interface ReporterHost extends UndoRedoHost {
+        resize(width: number, height: number): void;
+        closeEditor(): void;
+    }
+
+    export class ReporterBar {
+        root: svg.Group;
+        cursorText: svg.Text;
+
+        sizeButton: TextButton;
+        doneButton: StandaloneTextButton;
+        undoRedo: UndoRedoGroup;
+
+        protected sizePresets: [number, number][];
+        protected sizeIndex: number;
+
+        constructor(parent: svg.Group, protected host: ReporterHost, protected height: number) {
+            this.root = parent.group().id("sprite-editor-reporter-bar");
+            this.undoRedo = new UndoRedoGroup(this.root, host, UNDO_REDO_WIDTH, height);
+
+            this.sizeButton = mkTextButton("16x16", SIZE_BUTTON_WIDTH, height);
+            this.sizeButton.onClick(() => {
+                this.nextSize();
+            });
+
+            //this.root.appendChild(this.sizeButton.getElement());
+
+            this.doneButton = new StandaloneTextButton(lf("Done"), height);
+            this.doneButton.addClass("sprite-editor-confirm-button");
+            this.doneButton.onClick(() => this.host.closeEditor());
+
+            this.root.appendChild(this.doneButton.getElement());
+
+            this.sizePresets = [
+                [7, 7]
+            ];
+
+            this.cursorText = this.root.draw("text")
+                .appendClass("sprite-editor-text")
+                .appendClass("sprite-editor-label")
+                .setAttribute("dominant-baseline", "middle")
+                .setAttribute("dy", 2.5);
+        }
+
+        updateDimensions(width: number, height: number) {
+            this.sizeButton.setText(`${width}x${height}`);
+        }
+
+        hideCursor() {
+            this.cursorText.text("");
+        }
+
+        updateCursor(col: number, row: number) {
+            this.cursorText.text(`${col},${row}`);
+        }
+
+        updateUndoRedo(undo: boolean, redo: boolean) {
+            this.undoRedo.updateState(undo, redo);
+        }
+
+        layout(top: number, left: number, width: number) {
+            this.root.translate(left, top);
+
+            this.doneButton.layout();
+
+            const doneWidth = this.doneButton.width();
+
+            this.undoRedo.translate(width - UNDO_REDO_WIDTH - SIZE_CURSOR_MARGIN - doneWidth, 0);
+            this.doneButton.getElement().translate(width - doneWidth, 0);
+            this.cursorText.moveTo(SIZE_BUTTON_WIDTH + SIZE_CURSOR_MARGIN, this.height / 2);
+        }
+
+        setSizePresets(presets: [number, number][], currentWidth: number, currentHeight: number) {
+            this.sizePresets = presets;
+            this.sizeIndex = undefined;
+            for (let i = 0; i < presets.length; i++) {
+                const [w, h] = presets[i];
+                if (w === currentWidth && h === currentHeight) {
+                    this.sizeIndex = i;
+                    break;
+                }
+            }
+
+            this.updateDimensions(currentWidth, currentHeight);
+        }
+
+        protected nextSize() {
+            if (this.sizeIndex == undefined) {
+                this.sizeIndex = 0;
+            }
+            else {
+                this.sizeIndex = (this.sizeIndex + 1) % this.sizePresets.length;
+            }
+
+            const [w, h] = this.sizePresets[this.sizeIndex];
+            this.host.resize(w, h);
+        }
+    }
+}

--- a/pxtlib/round-matrix-editor/sidebar.ts
+++ b/pxtlib/round-matrix-editor/sidebar.ts
@@ -1,0 +1,210 @@
+/// <reference path="./buttons.ts" />
+namespace pxtmatrix {
+    import svg = pxt.svgUtil;
+    import lf = pxt.Util.lf;
+
+    export interface SideBarHost {
+        setActiveTool(tool: PaintTool): void;
+        setActiveColor(color: number): void;
+        setToolWidth(width: number): void;
+        setIconsToDefault(): void;
+    }
+
+    const TOOLBAR_WIDTH = 65;
+    const INNER_BUTTON_MARGIN = 3;
+    const PALETTE_BORDER_WIDTH = 1;
+    const BUTTON_GROUP_SPACING = 3;
+    const SELECTED_BORDER_WIDTH = 2;
+    const COLOR_PREVIEW_HEIGHT = 30;
+    const COLOR_MARGIN = 7;
+
+    const TOOL_BUTTON_WIDTH = (TOOLBAR_WIDTH - INNER_BUTTON_MARGIN) / 2;
+    const PALLETTE_SWATCH_WIDTH = (TOOLBAR_WIDTH - PALETTE_BORDER_WIDTH * 3) / 2;
+    const TOOL_BUTTON_TOP = TOOLBAR_WIDTH / 3 + BUTTON_GROUP_SPACING;
+    const PALETTE_TOP = TOOL_BUTTON_TOP + TOOL_BUTTON_WIDTH * 3 + INNER_BUTTON_MARGIN + COLOR_MARGIN;
+
+    export class SideBar {
+        root: svg.Group;
+        host: SideBarHost;
+        palette: string[];
+
+        protected colorSwatches: svg.Rect[];
+        protected pencilTool: Button;
+        protected eraseTool: Button;
+        protected rectangleTool: Button;
+        protected fillTool: Button;
+        protected marqueeTool: Button;
+
+        protected sizeGroup: svg.Group;
+        protected buttonGroup: svg.Group;
+        protected paletteGroup: svg.Group;
+
+        protected selectedTool: Button;
+        protected selectedSwatch: svg.Rect;
+        protected colorPreview: svg.Rect;
+
+        constructor(palette: string[], host: SideBarHost, parent: svg.Group) {
+            this.palette = palette;
+            this.host = host;
+            this.root = parent.group().id("sprite-editor-sidebar");
+
+            this.initSizes();
+            this.initTools();
+            this.initPalette();
+        }
+
+        public setTool(tool: PaintTool) {
+            this.host.setActiveTool(tool);
+
+            if (this.selectedTool) {
+                this.selectedTool.removeClass("selected");
+            }
+
+            this.selectedTool = this.getButtonForTool(tool);
+
+            if (this.selectedTool) {
+                this.selectedTool.addClass("selected");
+            }
+        }
+
+        public setColor(color: number) {
+            this.host.setActiveColor(color);
+
+            if (this.selectedSwatch) {
+                this.selectedSwatch.stroke("none");
+            }
+
+            this.selectedSwatch = this.colorSwatches[color];
+
+            if (this.selectedSwatch) {
+                // Border is multiplied by 2 and the excess is clipped away
+                this.selectedSwatch.stroke("orange", SELECTED_BORDER_WIDTH * 2);
+                this.colorPreview.fill(this.palette[color]);
+            }
+
+            // FIXME: Switch the tool to pencil
+        }
+
+        public setCursorSize(size: number) {
+            this.host.setToolWidth(size);
+        }
+
+        public setWidth(width: number) {
+            this.root.scale(width / TOOLBAR_WIDTH);
+        }
+
+        public translate(left: number, top: number) {
+            this.root.translate(left, top);
+        }
+
+        protected initSizes() {
+            this.sizeGroup = this.root.group().id("sprite-editor-cursor-buttons");
+            const buttonGroup = new CursorMultiButton(this.sizeGroup, TOOLBAR_WIDTH);
+            buttonGroup.onSelected(index => {
+                this.setCursorSize(1 + (index * 2));
+            });
+            // Sets the first button to show as selected
+            buttonGroup.selected = 0;
+            buttonGroup.buttons[0].setSelected(true);
+        }
+
+        protected initTools() {
+            this.buttonGroup = this.root.group()
+                .id("sprite-editor-tools")
+                .translate(0, TOOL_BUTTON_TOP);
+
+            this.pencilTool = this.initButton(lf("Pencil"), "\uf040", PaintTool.Normal);
+
+            this.eraseTool = this.initButton(lf("Erase"), "\uf12d", PaintTool.Erase);
+            this.eraseTool.translate(1 + TOOL_BUTTON_WIDTH + INNER_BUTTON_MARGIN, 0);
+
+            this.fillTool = this.initButton(lf("Fill"), "\uf102", PaintTool.Fill, true);
+            this.fillTool.translate(0, TOOL_BUTTON_WIDTH + INNER_BUTTON_MARGIN);
+
+            this.rectangleTool = this.initButton(lf("Rectangle"), "\uf096", PaintTool.Rectangle);
+            this.rectangleTool.translate(1 + TOOL_BUTTON_WIDTH + INNER_BUTTON_MARGIN, TOOL_BUTTON_WIDTH + INNER_BUTTON_MARGIN);
+
+            this.marqueeTool = this.initButton(lf("Marquee"), "\uf113", PaintTool.Marquee, true);
+            this.marqueeTool.translate(0, (TOOL_BUTTON_WIDTH + INNER_BUTTON_MARGIN) << 1);
+
+            this.setTool(PaintTool.Normal);
+        }
+
+        protected initPalette() {
+            this.paletteGroup = this.root.group().id("sprite-editor-palette")
+                .translate(0, PALETTE_TOP);
+
+            // Draw the background/borders for the entire palette
+            const bgHeight = COLOR_PREVIEW_HEIGHT + PALETTE_BORDER_WIDTH * 2;
+            this.paletteGroup.draw("rect")
+                .fill("#000000")
+                .size(TOOLBAR_WIDTH, bgHeight);
+
+            this.paletteGroup.draw("rect")
+                .fill("#000000")
+                .at(0, bgHeight + COLOR_MARGIN)
+                .size(TOOLBAR_WIDTH, PALETTE_BORDER_WIDTH + (this.palette.length >> 1) * (PALLETTE_SWATCH_WIDTH + PALETTE_BORDER_WIDTH));
+
+            // The highlighted swatch has an inner border. The only way to do that in SVG
+            // is to set the stroke to double the border width and clip the excess away
+            const clip = this.paletteGroup.def().create("clipPath", "sprite-editor-selected-color")
+                .clipPathUnits(true);
+
+            clip.draw("rect")
+                .at(0, 0)
+                .size(1, 1);
+
+            // Draw a preview of the current color
+            this.colorPreview = this.paletteGroup.draw("rect")
+                .at(PALETTE_BORDER_WIDTH, PALETTE_BORDER_WIDTH)
+                .size(TOOLBAR_WIDTH - PALETTE_BORDER_WIDTH * 2, COLOR_PREVIEW_HEIGHT);
+
+            // Draw the swatches for each color
+            this.colorSwatches = []
+            for (let i = 0; i < this.palette.length; i++) {
+                const col = i % 2;
+                const row = Math.floor(i / 2);
+
+                const swatch = this.paletteGroup
+                    .draw("rect")
+                    .size(PALLETTE_SWATCH_WIDTH, PALLETTE_SWATCH_WIDTH)
+                    .at(col ? PALETTE_BORDER_WIDTH * 2 + PALLETTE_SWATCH_WIDTH : PALETTE_BORDER_WIDTH, bgHeight + COLOR_MARGIN + PALETTE_BORDER_WIDTH + row * (PALETTE_BORDER_WIDTH + PALLETTE_SWATCH_WIDTH))
+                    .fill(this.palette[i])
+                    .clipPath("url(#sprite-editor-selected-color)")
+                    .onClick(() => this.setColor(i));
+                swatch.title(`${i}`)
+
+                this.colorSwatches.push(swatch);
+            }
+
+            this.setColor(0);
+        }
+
+        protected initButton(title: string, icon: string, tool: PaintTool, xicon = false) {
+            const btn = xicon ? mkXIconButton(icon, TOOL_BUTTON_WIDTH) : mkIconButton(icon, TOOL_BUTTON_WIDTH);
+            const shortcut = getPaintToolShortcut(tool);
+            if (shortcut) btn.shortcut(shortcut);
+            btn.title(title);
+
+            btn.onClick(() => {
+                this.host.setIconsToDefault();
+                this.setTool(tool);
+            });
+            this.buttonGroup.appendChild(btn.getElement());
+            return btn;
+        }
+
+        getButtonForTool(tool: PaintTool) {
+            switch (tool) {
+                case PaintTool.Normal:
+                case PaintTool.Line: return this.pencilTool;
+                case PaintTool.Erase: return this.eraseTool;
+                case PaintTool.Fill: return this.fillTool;
+                case PaintTool.Rectangle:
+                case PaintTool.Circle: return this.rectangleTool;
+                case PaintTool.Marquee: return this.marqueeTool;
+                default: return undefined;
+            }
+        }
+    }
+}

--- a/pxtlib/round-matrix-editor/spriteEditor.ts
+++ b/pxtlib/round-matrix-editor/spriteEditor.ts
@@ -1,0 +1,667 @@
+/// <reference path="./bitmap.ts" />
+/// <reference path="./tools.ts" />
+/// <reference path="./reporterBar.ts" />
+/// <reference path="./sidebar.ts" />
+/// <reference path="./gallery.ts" />
+/// <reference path="./header.ts" />
+
+namespace pxtmatrix {
+    import svg = pxt.svgUtil;
+    import lf = pxt.Util.lf;
+
+    export const TOTAL_HEIGHT = 500;
+
+    const PADDING = 10;
+
+    const DROP_DOWN_PADDING = 4;
+
+    // Height of toolbar (the buttons above the canvas)
+    export const HEADER_HEIGHT = 50;
+
+    // Spacing between the toolbar and the canvas
+    const HEADER_CANVAS_MARGIN = 10;
+
+    // Height of the bar that displays editor size and info below the canvas
+    const REPORTER_BAR_HEIGHT = 31;
+
+    // Spacing between the canvas and reporter bar
+    const REPORTER_BAR_CANVAS_MARGIN = 5;
+
+    // Spacing between palette and paint surface
+    const SIDEBAR_CANVAS_MARGIN = 10;
+
+    const SIDEBAR_WIDTH = 65;
+
+    // Total allowed height of paint surface
+    const CANVAS_HEIGHT = TOTAL_HEIGHT - HEADER_HEIGHT - HEADER_CANVAS_MARGIN
+        - REPORTER_BAR_HEIGHT - REPORTER_BAR_CANVAS_MARGIN - PADDING + DROP_DOWN_PADDING * 2;
+
+    const WIDTH = PADDING + SIDEBAR_WIDTH + SIDEBAR_CANVAS_MARGIN + CANVAS_HEIGHT + PADDING - DROP_DOWN_PADDING * 2;
+
+    export class SpriteEditor implements SideBarHost, SpriteHeaderHost {
+        private group: svg.Group;
+        private root: svg.SVG;
+
+        private paintSurface: CanvasGrid;
+        private sidebar: SideBar;
+        private header: SpriteHeader;
+        private bottomBar: ReporterBar;
+        private gallery: Gallery;
+
+        private state: CanvasState;
+
+        // When changing the size, keep the old bitmap around so that we can restore it
+        private cachedState: CanvasState;
+
+        private edit: Edit;
+        private activeTool: PaintTool = PaintTool.Normal;
+        private toolWidth = 1;
+        private color = 1;
+
+        private cursorCol = 0;
+        private cursorRow = 0;
+
+        private undoStack: CanvasState[] = [];
+        private redoStack: CanvasState[] = [];
+
+        private columns: number = 16;
+        private rows: number = 16;
+        private colors: string[];
+
+        private shiftDown: boolean = false;
+        private altDown: boolean = false;
+        private mouseDown: boolean = false;
+
+        private closeHandler: () => void;
+
+        constructor(bitmap: Bitmap, blocksInfo: pxtc.BlocksInfo, protected lightMode = false, colors: string[] = []) {
+            this.colors = colors
+            //pxt.appTarget.runtime.palette.slice(1);
+
+            // this.columns = bitmap.width;
+            // this.rows = bitmap.height;
+            this.rows = 7
+            this.columns = 7
+
+            this.state = new CanvasState(bitmap.copy())
+
+            this.root = new svg.SVG();
+            this.root.setClass("sprite-canvas-controls");
+            this.group = this.root.group();
+            this.createDefs();
+
+            this.paintSurface = new CanvasGrid(this.colors, this.state.copy(), this.lightMode);
+
+            this.paintSurface.drag((col, row) => {
+                this.debug("gesture (" + PaintTool[this.activeTool] + ")");
+                if (!this.altDown) {
+                    this.setCell(col, row, this.color, false);
+                }
+                this.bottomBar.updateCursor(col, row);
+            });
+
+            this.paintSurface.up((col, row) => {
+                this.debug("gesture end (" + PaintTool[this.activeTool] + ")");
+                if (this.altDown) {
+                    const color = this.state.image.get(col, row);
+                    this.sidebar.setColor(color);
+                } else {
+                    this.paintSurface.onEditEnd(col, row, this.edit);
+                    if (this.state.floatingLayer && !this.paintSurface.state.floatingLayer) {
+                        this.pushState(true);
+                        this.state = this.paintSurface.state.copy();
+                        this.rePaint();
+                    }
+                    this.commit();
+                    this.shiftAction();
+                }
+
+                this.mouseDown = false;
+            });
+
+            this.paintSurface.down((col, row) => {
+                if (!this.altDown) {
+                    this.setCell(col, row, this.color, false);
+                }
+                this.mouseDown = true;
+            });
+
+            this.paintSurface.move((col, row) => {
+                this.drawCursor(col, row);
+                this.shiftAction()
+                this.bottomBar.updateCursor(col, row);
+            });
+
+            this.paintSurface.leave(() => {
+                if (this.edit) {
+                    this.rePaint();
+                    if (this.edit.isStarted && !this.shiftDown) {
+                        this.commit();
+                    }
+                }
+                this.bottomBar.hideCursor();
+            });
+
+            this.sidebar = new SideBar(['url("#alpha-background")'].concat(this.colors), this, this.group);
+            this.sidebar.setColor(this.colors.length >= 3 ? 3 : 1); // colors omits 0
+
+            this.header = new SpriteHeader(this);
+            this.gallery = new Gallery(blocksInfo);
+            this.bottomBar = new ReporterBar(this.group, this, REPORTER_BAR_HEIGHT);
+
+            this.updateUndoRedo();
+        }
+
+        setCell(col: number, row: number, color: number, commit: boolean): void {
+            if (commit) {
+                this.state.image.set(col, row, color);
+                this.paintCell(col, row, color);
+            }
+            else if (this.edit) {
+                if (!this.edit.isStarted) {
+                    this.paintSurface.onEditStart(col, row, this.edit);
+
+                    if (this.state.floatingLayer && !this.paintSurface.state.floatingLayer) {
+                        this.pushState(true);
+                        this.state = this.paintSurface.state.copy();
+                    }
+                }
+                this.edit.update(col, row);
+                this.cursorCol = col;
+                this.cursorRow = row;
+                this.paintEdit(this.edit, col, row);
+            }
+        }
+
+        render(el: HTMLDivElement): void {
+            el.appendChild(this.header.getElement());
+            el.appendChild(this.gallery.getElement());
+            this.paintSurface.render(el);
+            el.appendChild(this.root.el);
+            this.layout();
+            this.root.attr({ "width": this.outerWidth() + "px", "height": this.outerHeight() + "px" });
+            this.root.el.style.position = "absolute";
+            this.root.el.style.top = "0px";
+            this.root.el.style.left = "0px";
+        }
+
+        layout(): void {
+            if (!this.root) {
+                return;
+            }
+
+            this.paintSurface.setGridDimensions(CANVAS_HEIGHT);
+
+            // The width of the palette + editor
+            const paintAreaTop = HEADER_HEIGHT + HEADER_CANVAS_MARGIN;
+            const paintAreaLeft = PADDING + SIDEBAR_WIDTH + SIDEBAR_CANVAS_MARGIN;
+
+            this.sidebar.translate(PADDING, paintAreaTop);
+            this.paintSurface.updateBounds(paintAreaTop, paintAreaLeft, CANVAS_HEIGHT, CANVAS_HEIGHT);
+            this.bottomBar.layout(paintAreaTop + CANVAS_HEIGHT + REPORTER_BAR_CANVAS_MARGIN, paintAreaLeft, CANVAS_HEIGHT);
+
+            this.gallery.layout(0, HEADER_HEIGHT, TOTAL_HEIGHT - HEADER_HEIGHT);
+            this.header.layout();
+        }
+
+        rePaint() {
+            this.paintSurface.repaint();
+        }
+
+        setActiveColor(color: number, setPalette = false) {
+            if (setPalette) {
+            }
+            else if (this.color != color) {
+                this.color = color;
+
+                // If the user is erasing, go back to pencil
+                if (this.activeTool === PaintTool.Erase) {
+                    this.sidebar.setTool(PaintTool.Normal);
+                } else {
+                    this.updateEdit();
+                }
+            }
+        }
+
+        setActiveTool(tool: PaintTool) {
+            if (this.activeTool != tool) {
+                this.activeTool = tool;
+                this.updateEdit()
+            }
+        }
+
+        setToolWidth(width: number) {
+            if (this.toolWidth != width) {
+                this.toolWidth = width;
+                this.updateEdit();
+            }
+        }
+
+        initializeUndoRedo(undoStack: CanvasState[], redoStack: CanvasState[]) {
+            if (undoStack) {
+                this.undoStack = undoStack;
+            }
+            if (redoStack) {
+                this.redoStack = redoStack;
+            }
+            this.updateUndoRedo();
+        }
+
+        getUndoStack() {
+            return this.undoStack.slice();
+        }
+
+        getRedoStack() {
+            return this.redoStack.slice();
+        }
+
+        undo() {
+            if (this.undoStack.length) {
+                this.debug("undo");
+                const todo = this.undoStack.pop();
+                this.pushState(false);
+
+                // The current state is at the top of the stack unless the user has pressed redo, so
+                // we need to discard it
+                if (todo.equals(this.state)) {
+                    this.undo();
+                    return;
+                }
+                this.restore(todo);
+            }
+            this.updateUndoRedo();
+        }
+
+        redo() {
+            if (this.redoStack.length) {
+                this.debug("redo");
+                const todo = this.redoStack.pop();
+                this.pushState(true);
+                this.restore(todo);
+            }
+            this.updateUndoRedo();
+        }
+
+        resize(width: number, height: number) {
+            if (!this.cachedState) {
+                this.cachedState = this.state.copy();
+                this.undoStack.push(this.cachedState)
+                this.redoStack = [];
+            }
+            this.state.image = resizeBitmap(this.cachedState.image, width, height);
+            this.afterResize(true);
+        }
+
+        setSizePresets(presets: [number, number][]) {
+            this.bottomBar.setSizePresets(presets, this.columns, this.rows);
+        }
+
+        canvasWidth() {
+            return this.columns;
+        }
+
+        canvasHeight() {
+            return this.rows;
+        }
+
+        outerWidth() {
+            return WIDTH;
+        }
+
+        outerHeight() {
+            return TOTAL_HEIGHT;
+        }
+
+        bitmap() {
+            return this.state;
+        }
+
+        showGallery() {
+            this.gallery.show((result: Bitmap, err?: string) => {
+                if (err && err !== "cancelled") {
+                    console.error(err);
+                }
+                else if (result) {
+                    this.redoStack = [];
+                    this.pushState(true);
+                    this.restore(new CanvasState(result));
+                    this.hideGallery();
+                    this.header.toggle.toggle(true);
+                }
+            });
+        }
+
+        hideGallery() {
+            this.gallery.hide();
+        }
+
+        closeEditor() {
+            if (this.closeHandler) {
+                const ch = this.closeHandler;
+                this.closeHandler = undefined;
+                ch();
+            }
+            if (this.state.floatingLayer) {
+                this.state.mergeFloatingLayer();
+                this.pushState(true);
+            }
+        }
+
+        onClose(handler: () => void) {
+            this.closeHandler = handler;
+        }
+
+        switchIconTo(tool: PaintTool) {
+            if (this.activeTool === tool) return;
+
+            const btn = this.sidebar.getButtonForTool(tool) as TextButton;
+
+            switch (tool) {
+                case PaintTool.Rectangle:
+                    updateIcon(btn, "\uf096", lf("Rectangle"));
+                    break;
+                case PaintTool.Circle:
+                    updateIcon(btn, "\uf10c", lf("Circle"));
+                    break;
+                case PaintTool.Normal:
+                    updateIcon(btn, "\uf040", lf("Pencil"));
+                    break;
+                case PaintTool.Line:
+                    updateIcon(btn, "\uf07e", lf("Line"));
+                    break;
+                default:  // no alternate icon, do not change
+                    return;
+            }
+
+            btn.onClick(() => {
+                if (tool != PaintTool.Circle && tool != PaintTool.Line) {
+                    this.setIconsToDefault();
+                    this.sidebar.setTool(tool);
+                }
+            });
+
+            function updateIcon(button: TextButton, text: string, title: string) {
+                const shortcut = getPaintToolShortcut(tool);
+
+                button.setText(text);
+                button.title(title);
+                button.shortcut(shortcut);
+            }
+        }
+
+        setIconsToDefault() {
+            this.switchIconTo(PaintTool.Rectangle);
+            this.switchIconTo(PaintTool.Normal);
+        }
+
+        private keyDown = (event: KeyboardEvent) => {
+            if (event.keyCode == 16) { // Shift
+                this.shiftDown = true;
+                this.shiftAction();
+            }
+
+            if (event.keyCode === 18) { // Alt
+                this.discardEdit();
+                this.paintSurface.setEyedropperMouse(true);
+                this.altDown = true;
+            }
+
+            if (this.state.floatingLayer) {
+                let didSomething = true;
+
+                switch (event.keyCode) {
+                    case 8: // backspace
+                    case 46: // delete
+                        event.preventDefault();
+                        event.stopPropagation();
+                        this.state.floatingLayer = undefined;
+                        break;
+                    case 37: // Left arrow
+                        this.state.layerOffsetX--;
+                        break;
+                    case 38: // Up arrow
+                        this.state.layerOffsetY--;
+                        break;
+                    case 39: // Right arrow
+                        this.state.layerOffsetX++;
+                        break;
+                    case 40: // Down arrow
+                        this.state.layerOffsetY++;
+                        break;
+                    default:
+                        didSomething = false;
+                }
+
+                if (didSomething) {
+                    this.updateEdit();
+                    this.pushState(true);
+                    this.paintSurface.restore(this.state, true);
+                }
+            }
+
+            const tools = [
+                PaintTool.Fill,
+                PaintTool.Normal,
+                PaintTool.Rectangle,
+                PaintTool.Erase,
+                PaintTool.Circle,
+                PaintTool.Line,
+                PaintTool.Marquee
+            ]
+
+            tools.forEach(tool => {
+                if (event.key === getPaintToolShortcut(tool)) {
+                    this.setIconsToDefault();
+                    this.switchIconTo(tool);
+                    this.sidebar.setTool(tool);
+                }
+            });
+
+            const zeroKeyCode = 48;
+            const nineKeyCode = 57;
+
+            if (event.keyCode >= zeroKeyCode && event.keyCode <= nineKeyCode) {
+                let color = event.keyCode - zeroKeyCode;
+                if (this.shiftDown) {
+                    color += 9;
+                }
+                if (color <= this.colors.length) { // colors omits 0
+                    this.sidebar.setColor(color);
+                }
+            }
+        }
+
+        private keyUp = (event: KeyboardEvent) => {
+            // If not drawing a circle, switch back to Rectangle and Pencil
+            if (event.keyCode === 16) { // Shift
+                this.shiftDown = false;
+                this.clearShiftAction();
+            } else if (event.keyCode === 18) { // Alt
+                this.altDown = false;
+                this.paintSurface.setEyedropperMouse(false);
+                this.updateEdit();
+            }
+        }
+
+        private undoRedoEvent = (event: KeyboardEvent) => {
+            const controlOrMeta = event.ctrlKey || event.metaKey; // ctrl on windows, meta on mac
+            if (event.key === "Undo" || (controlOrMeta && event.key === "z")) {
+                this.undo();
+                event.preventDefault();
+                event.stopPropagation();
+            } else if (event.key === "Redo" || (controlOrMeta && event.key === "y")) {
+                this.redo();
+                event.preventDefault();
+                event.stopPropagation();
+            }
+        }
+
+        addKeyListeners() {
+            document.addEventListener("keydown", this.keyDown);
+            document.addEventListener("keyup", this.keyUp);
+            document.addEventListener("keydown", this.undoRedoEvent, true);
+        }
+
+        removeKeyListeners() {
+            document.removeEventListener("keydown", this.keyDown);
+            document.removeEventListener("keyup", this.keyUp);
+            document.removeEventListener("keydown", this.undoRedoEvent, true);
+            this.paintSurface.removeMouseListeners();
+        }
+
+        private afterResize(showOverlay: boolean) {
+            this.columns = this.state.width;
+            this.rows = this.state.height;
+            this.paintSurface.restore(this.state, true);
+            this.bottomBar.updateDimensions(this.columns, this.rows);
+            this.layout();
+
+            if (showOverlay) this.paintSurface.showResizeOverlay();
+
+            // Canvas size changed and some edits rely on that (like paint)
+            this.updateEdit();
+        }
+
+        private drawCursor(col: number, row: number) {
+            if (this.edit) {
+                this.paintSurface.drawCursor(this.edit, col, row);
+            }
+        }
+
+        private paintEdit(edit: Edit, col: number, row: number, gestureEnd = false) {
+            this.paintSurface.restore(this.state);
+            this.paintSurface.applyEdit(edit, col, row, gestureEnd);
+        }
+
+        private commit() {
+            if (this.edit) {
+                if (this.cachedState) {
+                    this.cachedState = undefined;
+                }
+                this.pushState(true);
+                this.paintEdit(this.edit, this.cursorCol, this.cursorRow, true);
+                this.state = this.paintSurface.state.copy();
+                this.updateEdit();
+                this.redoStack = [];
+            }
+        }
+
+        private pushState(undo: boolean) {
+            const stack = undo ? this.undoStack : this.redoStack;
+            if (stack.length && this.state.equals(stack[stack.length - 1])) {
+                // Don't push empty commits
+                return;
+            }
+
+            stack.push(this.state.copy());
+            this.updateUndoRedo();
+        }
+
+        private discardEdit() {
+            if (this.edit) {
+                this.edit = undefined;
+                this.rePaint();
+            }
+        }
+
+        private updateEdit() {
+            if (!this.altDown) {
+                this.edit = this.newEdit();
+            }
+        }
+
+        private restore(state: CanvasState) {
+            if (state.width !== this.state.width || state.height !== this.state.height) {
+                this.state = state;
+                this.afterResize(false);
+            }
+            else {
+                this.state = state.copy();
+                this.paintSurface.restore(state, true);
+            }
+        }
+
+        private updateUndoRedo() {
+            this.bottomBar.updateUndoRedo(this.undoStack.length === 0, this.redoStack.length === 0)
+        }
+
+        private paintCell(col: number, row: number, color: number) {
+            this.paintSurface.writeColor(col, row, color);
+        }
+
+        private newEdit() {
+            switch (this.activeTool) {
+                case PaintTool.Normal:
+                    return new PaintEdit(this.columns, this.rows, this.color, this.toolWidth);
+                case PaintTool.Rectangle:
+                    return new OutlineEdit(this.columns, this.rows, this.color, this.toolWidth);
+                case PaintTool.Outline:
+                    return new OutlineEdit(this.columns, this.rows, this.color, this.toolWidth);
+                case PaintTool.Line:
+                    return new LineEdit(this.columns, this.rows, this.color, this.toolWidth);
+                case PaintTool.Circle:
+                    return new CircleEdit(this.columns, this.rows, this.color, this.toolWidth);
+                case PaintTool.Erase:
+                    return new PaintEdit(this.columns, this.rows, 0, this.toolWidth);
+                case PaintTool.Fill:
+                    return new FillEdit(this.columns, this.rows, this.color, this.toolWidth);
+                case PaintTool.Marquee:
+                    return new MarqueeEdit(this.columns, this.rows, this.color, this.toolWidth);
+            }
+        }
+
+        private shiftAction() {
+            if (!this.shiftDown || this.altDown)
+                return;
+
+            switch (this.activeTool) {
+                case PaintTool.Line:
+                case PaintTool.Rectangle:
+                case PaintTool.Circle:
+                    this.setCell(this.paintSurface.mouseCol, this.paintSurface.mouseRow, this.color, false);
+                    break;
+            }
+        }
+
+        private clearShiftAction() {
+            if (this.mouseDown)
+                return;
+
+            switch (this.activeTool) {
+                case PaintTool.Line:
+                case PaintTool.Rectangle:
+                case PaintTool.Circle:
+                    this.updateEdit();
+                    this.paintSurface.restore(this.state, true);
+                    break;
+            }
+        }
+
+        private debug(msg: string) {
+            // if (this.debugText) {
+            //     this.debugText.text("DEBUG: " + msg);
+            // }
+        }
+
+        private createDefs() {
+            this.root.define(defs => {
+                const p = defs.create("pattern", "alpha-background")
+                    .size(10, 10)
+                    .units(svg.PatternUnits.userSpaceOnUse);
+
+                p.draw("rect")
+                    .at(0, 0)
+                    .size(10, 10)
+                    .fill("white");
+                p.draw("rect")
+                    .at(0, 0)
+                    .size(5, 5)
+                    .fill("#dedede");
+                p.draw("rect")
+                    .at(5, 5)
+                    .size(5, 5)
+                    .fill("#dedede");
+            })
+        }
+    }
+}

--- a/pxtlib/round-matrix-editor/tools.ts
+++ b/pxtlib/round-matrix-editor/tools.ts
@@ -1,0 +1,483 @@
+/// <reference path="./bitmap.ts" />
+
+namespace pxtmatrix {
+    export enum PaintTool {
+        Normal = 0,
+        Rectangle = 1,
+        Outline = 2,
+        Circle = 3,
+        Fill = 4,
+        Line = 5,
+        Erase = 6,
+        Marquee = 7,
+    }
+
+    export function getPaintToolShortcut(tool: PaintTool) {
+        switch (tool) {
+            case PaintTool.Normal:
+                return "p";
+            case PaintTool.Rectangle:
+                return "r";
+            case PaintTool.Circle:
+                return "c";
+            case PaintTool.Fill:
+                return "b";
+            case PaintTool.Line:
+                return "l";
+            case PaintTool.Erase:
+                return "e";
+            case PaintTool.Marquee:
+                return "s";
+            default:
+                return undefined;
+        }
+    }
+
+    export class Cursor {
+        offsetX: number;
+        offsetY: number;
+        constructor(public readonly width: number, public readonly height: number) {
+            this.offsetX = -(width >> 1);
+            this.offsetY = -(height >> 1);
+        }
+    }
+
+    export abstract class Edit {
+        protected startCol: number;
+        protected startRow: number;
+        isStarted: boolean;
+        showPreview: boolean;
+
+        constructor (protected canvasWidth: number, protected canvasHeight: number, public color: number, protected toolWidth: number) {
+        }
+
+        public abstract update(col: number, row: number): void;
+        protected abstract doEditCore(state: CanvasState): void;
+
+        public doEdit(state: CanvasState): void {
+            if (this.isStarted) {
+                this.doEditCore(state);
+            }
+        }
+
+
+        start(cursorCol: number, cursorRow: number, state: CanvasState) {
+            this.isStarted = true;
+            this.startCol = cursorCol;
+            this.startRow = cursorRow;
+
+            state.mergeFloatingLayer();
+        }
+
+
+        end(col: number, row: number, state: CanvasState): void {
+
+        }
+
+
+        getCursor(): Cursor {
+            return new Cursor(this.toolWidth, this.toolWidth);
+        }
+
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            draw(col, row);
+        }
+    }
+
+    export abstract class SelectionEdit extends Edit {
+        protected endCol: number;
+        protected endRow: number;
+        protected isDragged: boolean;
+
+        update(col: number, row: number) {
+            this.endCol = col;
+            this.endRow = row;
+
+            if (!this.isDragged && !(col == this.startCol && row == this.startRow)) {
+                this.isDragged = true;
+            }
+        }
+
+        protected topLeft(): Coord {
+            return {
+                x: Math.min(this.startCol, this.endCol),
+                y: Math.min(this.startRow, this.endRow)
+            };
+        }
+
+        protected bottomRight(): Coord {
+            return {
+                x: Math.max(this.startCol, this.endCol),
+                y: Math.max(this.startRow, this.endRow)
+        };
+        }
+    }
+
+    /**
+     * Regular old drawing tool
+     */
+    export class PaintEdit extends Edit {
+        protected mask: Bitmask;
+        showPreview = true;
+
+        constructor (canvasWidth: number, canvasHeight: number, color: number, toolWidth: number) {
+            super(canvasWidth, canvasHeight, color, toolWidth);
+            this.mask = new Bitmask(canvasWidth, canvasHeight);
+        }
+
+        update(col: number, row: number) {
+            // Interpolate (Draw a line) from startCol, startRow to col, row
+            this.interpolate(this.startCol, this.startRow, col, row);
+
+            this.startCol = col;
+            this.startRow = row;
+        }
+
+        // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
+        protected interpolate(x0: number, y0: number, x1: number, y1: number) {
+            const dx = x1 - x0;
+            const dy = y1 - y0;
+            const draw = (c: number, r: number) => this.mask.set(c, r);
+            if (dx === 0) {
+                const startY = dy >= 0 ? y0 : y1;
+                const endY = dy >= 0 ? y1 : y0;
+                for (let y = startY; y <= endY; y++) {
+                    this.drawCore(x0, y, draw);
+                }
+                return;
+            }
+
+            const xStep = dx > 0 ? 1 : -1;
+            const yStep = dy > 0 ? 1 : -1;
+            const dErr = Math.abs(dy / dx);
+
+            let err = 0;
+            let y = y0;
+            for (let x = x0; xStep > 0 ? x <= x1 : x >= x1; x += xStep) {
+                this.drawCore(x, y, draw);
+                err += dErr;
+                while (err >= 0.5) {
+                    if (yStep > 0 ? y <= y1 : y >= y1) {
+                        this.drawCore(x, y, draw);
+                    }
+                    y += yStep;
+                    err -= 1;
+                }
+            }
+        }
+
+        protected doEditCore(state: CanvasState) {
+            for (let c = 0; c < state.width; c++) {
+                for (let r = 0; r < state.height; r++) {
+                    if (this.mask.get(c, r)) {
+                        state.image.set(c, r, this.color);
+                    }
+                }
+            }
+        }
+
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            this.drawCore(col, row, draw);
+        }
+
+        protected drawCore(col: number, row: number, setPixel: (col: number, row: number) => void) {
+            col = col - Math.floor(this.toolWidth / 2);
+            row = row - Math.floor(this.toolWidth / 2);
+            for (let i = 0; i < this.toolWidth; i++) {
+                for (let j = 0; j < this.toolWidth; j++) {
+                    const c = col + i;
+                    const r = row + j;
+
+                    if (c >= 0 && c < this.canvasWidth && r >= 0 && r < this.canvasHeight) {
+                        setPixel(col + i, row + j);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Tool for drawing filled rectangles
+     */
+    export class RectangleEdit extends SelectionEdit {
+        showPreview = true;
+
+        protected doEditCore(state: CanvasState) {
+            const tl = this.topLeft();
+            const br = this.bottomRight();
+            for (let c = tl.x; c <= br.x; c++) {
+                for (let r = tl.y; r <= br.y; r++) {
+                    state.image.set(c, r, this.color);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tool for drawing empty rectangles
+     */
+    export class OutlineEdit extends SelectionEdit {
+        showPreview = true;
+
+        protected doEditCore(state: CanvasState) {
+            let tl = this.topLeft();
+            tl.x -= this.toolWidth >> 1;
+            tl.y -= this.toolWidth >> 1;
+
+            let br = this.bottomRight();
+            br.x += this.toolWidth >> 1;
+            br.y += this.toolWidth >> 1;
+
+            for (let i = 0; i < this.toolWidth; i++) {
+                this.drawRectangle(state,
+                    {x: tl.x + i, y: tl.y + i},
+                    {x: br.x - i, y: br.y - i}
+                );
+            }
+        }
+
+        protected drawRectangle(state: CanvasState, tl: Coord, br: Coord) {
+            if (tl.x > br.x || tl.y > br.y) return;
+
+            for (let c = tl.x; c <= br.x; c++) {
+                state.image.set(c, tl.y, this.color);
+                state.image.set(c, br.y, this.color);
+            }
+            for (let r = tl.y; r <= br.y; r++) {
+                state.image.set(tl.x, r, this.color);
+                state.image.set(br.x, r, this.color);
+            }
+        }
+
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            this.drawCore(col, row, draw);
+        }
+
+        protected drawCore(col: number, row: number, setPixel: (col: number, row: number) => void) {
+            col = col - Math.floor(this.toolWidth / 2);
+            row = row - Math.floor(this.toolWidth / 2);
+            for (let i = 0; i < this.toolWidth; i++) {
+                for (let j = 0; j < this.toolWidth; j++) {
+                    const c = col + i;
+                    const r = row + j;
+
+                    if (c >= 0 && c < this.canvasWidth && r >= 0 && r < this.canvasHeight) {
+                        setPixel(col + i, row + j);
+                    }
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Tool for drawing straight lines
+     */
+    export class LineEdit extends SelectionEdit {
+        showPreview = true;
+
+        protected doEditCore(state: CanvasState) {
+            this.bresenham(this.startCol, this.startRow, this.endCol, this.endRow, state);
+        }
+
+        // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
+        protected bresenham(x0: number, y0: number, x1: number, y1: number, state: CanvasState) {
+            const dx = x1 - x0;
+            const dy = y1 - y0;
+            const draw = (c: number, r: number) => state.image.set(c, r, this.color);
+            if (dx === 0) {
+                const startY = dy >= 0 ? y0 : y1;
+                const endY = dy >= 0 ? y1 : y0;
+                for (let y = startY; y <= endY; y++) {
+                    this.drawCore(x0, y, draw);
+                }
+                return;
+            }
+
+            const xStep = dx > 0 ? 1 : -1;
+            const yStep = dy > 0 ? 1 : -1;
+            const dErr = Math.abs(dy / dx);
+
+            let err = 0;
+            let y = y0;
+            for (let x = x0; xStep > 0 ? x <= x1 : x >= x1; x += xStep) {
+                this.drawCore(x, y, draw);
+                err += dErr;
+                while (err >= 0.5) {
+                    if (yStep > 0 ? y <= y1 : y >= y1) {
+                        this.drawCore(x, y, draw);
+                    }
+                    y += yStep;
+                    err -= 1;
+                }
+            }
+        }
+
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            this.drawCore(col, row, draw);
+        }
+
+        // This is surely not the most efficient approach for drawing thick lines...
+        protected drawCore(col: number, row: number, draw: (c: number, r: number) => void) {
+            col = col - Math.floor(this.toolWidth / 2);
+            row = row - Math.floor(this.toolWidth / 2);
+            for (let i = 0; i < this.toolWidth; i++) {
+                for (let j = 0; j < this.toolWidth; j++) {
+                    const c = col + i;
+                    const r = row + j;
+
+                    draw(c, r);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tool for circular outlines
+     */
+    export class CircleEdit extends SelectionEdit {
+        showPreview = true;
+
+        protected doEditCore(state: CanvasState) {
+            const tl = this.topLeft();
+            const br = this.bottomRight();
+            const dx = br.x - tl.x;
+            const dy = br.y - tl.y;
+
+            const radius = Math.floor(Math.hypot(dx, dy));
+            const cx = this.startCol;
+            const cy = this.startRow;
+
+            this.midpoint(cx, cy, radius, state);
+        }
+
+        // https://en.wikipedia.org/wiki/Midpoint_circle_algorithm
+        midpoint(cx: number, cy: number, radius: number, state: CanvasState) {
+            let x = radius - 1;
+            let y = 0;
+            let dx = 1;
+            let dy = 1;
+            let err = dx - (radius * 2);
+            while (x >= y) {
+                state.image.set(cx + x, cy + y, this.color);
+                state.image.set(cx + x, cy - y, this.color);
+                state.image.set(cx + y, cy + x, this.color);
+                state.image.set(cx + y, cy - x, this.color);
+                state.image.set(cx - y, cy + x, this.color);
+                state.image.set(cx - y, cy - x, this.color);
+                state.image.set(cx - x, cy + y, this.color);
+                state.image.set(cx - x, cy - y, this.color);
+                if (err <= 0) {
+                    y++;
+                    err += dy;
+                    dy += 2;
+                }
+                if (err > 0) {
+                    x--;
+                    dx += 2;
+                    err += dx - (radius * 2);
+                }
+            }
+        }
+
+        getCursor(): Cursor {
+            return new Cursor(1, 1);
+        }
+    }
+
+
+    export class FillEdit extends Edit {
+        protected col: number;
+        protected row: number;
+        showPreview = true;
+
+        start(col: number, row: number, state: CanvasState) {
+            this.isStarted = true;
+            this.col = col;
+            this.row = row;
+
+            state.mergeFloatingLayer();
+        }
+
+        update(col: number, row: number) {
+            this.col = col;
+            this.row = row;
+        }
+
+        protected doEditCore(state: CanvasState) {
+            const replColor = state.image.get(this.col, this.row);
+            if (replColor === this.color) {
+                return;
+            }
+
+            const mask = new Bitmask(state.width, state.height);
+            mask.set(this.col, this.row);
+            const q: Coord[] = [{x: this.col, y: this.row}];
+            while (q.length) {
+                const curr = q.pop();
+                if (state.image.get(curr.x, curr.y) === replColor) {
+                    state.image.set(curr.x, curr.y, this.color);
+                    tryPush(curr.x + 1, curr.y);
+                    tryPush(curr.x - 1, curr.y);
+                    tryPush(curr.x, curr.y + 1);
+                    tryPush(curr.x, curr.y - 1);
+                }
+            }
+
+            function tryPush(x: number, y: number) {
+                if (x >= 0 && x < mask.width && y >= 0 && y < mask.height && !mask.get(x, y)) {
+                    mask.set(x, y);
+                    q.push({x: x, y: y});
+                }
+            }
+        }
+
+        getCursor(): Cursor {
+            return new Cursor(1, 1);
+        }
+    }
+
+
+    export class MarqueeEdit extends SelectionEdit {
+        protected isMove = false;
+        showPreview = false;
+
+        start(cursorCol: number, cursorRow: number, state: CanvasState) {
+            this.isStarted = true;
+            this.startCol = cursorCol;
+            this.startRow = cursorRow;
+            if (state.floatingLayer) {
+                if (state.inFloatingLayer(cursorCol, cursorRow)) {
+                    this.isMove = true;
+                } else {
+                    state.mergeFloatingLayer();
+                }
+            }
+        }
+
+        end(cursorCol: number, cursorRow: number, state: CanvasState) {
+            if (!this.isDragged && state.floatingLayer) {
+                state.mergeFloatingLayer();
+            }
+        }
+
+        protected doEditCore(state: CanvasState): void {
+            const tl = this.topLeft();
+            const br = this.bottomRight();
+
+            if (this.isDragged) {
+                if (this.isMove) {
+                    state.layerOffsetX = state.floatingLayer.x0 + this.endCol - this.startCol;
+                    state.layerOffsetY = state.floatingLayer.y0 + this.endRow - this.startRow;
+                }
+                else {
+                    state.copyToLayer(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, true);
+                }
+            }
+        }
+
+        getCursor(): Cursor {
+            return undefined;
+        }
+    }
+}

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -77,7 +77,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             attributes: {
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
                 icon: "loops",
-                weight: 50.09,
+                weight: 9,
                 paramDefl: {}
             }
         };
@@ -244,7 +244,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 }],
             attributes: {
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
-                weight: 50.08,
+                weight: 8,
                 icon: "logic",
                 paramDefl: {}
             }
@@ -259,7 +259,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 return false;
             },
             attributes: {
-                weight: 50.07,
+                weight: 7,
                 icon: "variables",
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
                 paramDefl: {}
@@ -455,7 +455,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             ],
             attributes: {
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
-                weight: 50.06,
+                weight: 6,
                 icon: "math",
                 paramDefl: {}
             }
@@ -471,7 +471,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             },
             attributes: {
                 advanced: true,
-                weight: 50.08,
+                weight: 8,
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
                 icon: "functions",
                 paramDefl: {}
@@ -599,7 +599,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             ],
             attributes: {
                 advanced: true,
-                weight: 50.07,
+                weight: 7,
                 icon: "arrays",
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
                 paramDefl: {}
@@ -652,7 +652,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
             ],
             attributes: {
                 advanced: false,
-                weight: 99,
+                weight: 89,
                 icon: "text",
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
                 paramDefl: {}

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -543,8 +543,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
             ],
             attributes: {
-                advanced: true,
-                weight: 50.06,
+                weight: 88,
                 icon: "text",
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,
                 paramDefl: {}


### PR DESCRIPTION
## Feature ##
Rearranges toolboxes in the Block and Javascript editors to match each other.
This PR makes adjustments that when combined with the adjustments from this PR for PXT-LB reorder the snippets: https://github.com/littlebitselectronics/pxt-lb/pull/23

## Approach ##
Adjusted snippet `weight` attributes.

<img width="1907" alt="Screen Shot 2019-11-26 at 11 30 12 AM" src="https://user-images.githubusercontent.com/8815487/69663369-58fc3b80-1043-11ea-9a27-91dcf9196e62.png">
<img width="1895" alt="Screen Shot 2019-11-26 at 11 30 29 AM" src="https://user-images.githubusercontent.com/8815487/69663370-58fc3b80-1043-11ea-84b6-8617cf642480.png">
