### PR TITLE
[LBOS-1267] 🚑 Fix matrix and display drawer

### DIFF
--- a/pxtblocks/fields/field_roundMatrixSmall.ts
+++ b/pxtblocks/fields/field_roundMatrixSmall.ts
@@ -55,7 +55,7 @@ namespace pxtblockly {
               return;
           }
           // Build the DOM.
-          this.fieldGroup_ = Blockly.utils.createSvgElement('g', {}, null);
+          this.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null);
           if (!this.visible_) {
               (this.fieldGroup_ as any).style.display = 'none';
           }


### PR DESCRIPTION
## Feature ##
Fix for bug that prevented drawer from opening when 'Display' was selected in the code block editor.

Before:
![Screen Shot 2019-12-02 at 10 42 22 AM](https://user-images.githubusercontent.com/8815487/69982130-fd252d00-14f0-11ea-9874-a1f99a5df2cb.png)
After:
![Screen Shot 2019-12-02 at 10 45 57 AM](https://user-images.githubusercontent.com/8815487/69982141-01e9e100-14f1-11ea-8f7d-4ed3bdedca42.png)