### PR TITLE
Restore LBOS-1046 'updatefilters' editor controller action

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -66,6 +66,7 @@ declare namespace pxt.editor {
         | "renderxml"
         | "renderbyblockid"
         | "setscale"
+        | "updatefilters"
         | "startactivity"
         | "saveproject"
         | "compile"
@@ -1028,6 +1029,7 @@ declare namespace pxt.editor {
         handleExtensionRequest(request: pxt.editor.ExtensionRequest): void;
 
         fireResize(): void;
+        updateFilters(filters?: pxt.editor.ProjectFilters): void;
         updateEditorLogo(left: number, rgba?: string): number;
 
         loadBlocklyAsync(): Promise<void>;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -95,6 +95,15 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                 return Promise.resolve()
                                     .then(() => projectView.editor.setScale(zoommsg.scale));
                             }
+                            case "updatefilters": return Promise.resolve()
+                                .then(() => {
+                                    // Restored from LBOS-1046 (lost in the v12 upstream merge).
+                                    // p2-studio CodingCanvas sends { type: 'pxteditor', action: 'updatefilters',
+                                    // filters: {...} } when active bits change, so the toolbox can be restricted
+                                    // to blocks/namespaces appropriate for the connected codeBit / BLE bit.
+                                    const filters = (data as any).filters as pxt.editor.ProjectFilters;
+                                    projectView.updateFilters(filters);
+                                });
                             case "stopsimulator": {
                                 const stop = data as pxt.editor.EditorMessageStopRequest;
                                 return Promise.resolve()


### PR DESCRIPTION
## Problem

p2-studio's CodingCanvas sends `{ type: 'pxteditor', action: 'updatefilters', filters: {...} }` when active bits change, so the toolbox can be restricted to blocks/namespaces appropriate for the connected codeBit or BLE bit. After the v12.2.34 upstream merge (#19), the editor silently ignored these messages — bit-specific toolbox filtering was broken in FUSE.

## Why

The original LBOS-1046 work (2019, PR #4) added the action handler. The v12.2.34 merge preserved the `updateFilters` IMPLEMENTATION in `webapp/src/app.tsx` (line 591) but DROPPED the controller wiring — the `case "updatefilters"` was lost in `pxteditor/editorcontroller.ts`, and the corresponding union member and IProjectView declaration weren't carried over either.

## Fix

- `localtypings/pxteditor.d.ts`: add `"updatefilters"` to the editor action union; add `updateFilters(filters?: pxt.editor.ProjectFilters)` to `IProjectView`.
- `pxteditor/editorcontroller.ts`: re-add `case "updatefilters"` calling `projectView.updateFilters((data as any).filters)`.

## Verification

End-to-end against the FUSE editor with `ENABLE_PXT_FILTERS = true` re-enabled in p2-studio:

- Toolbox categories before flag flip: **19** (all categories visible)
- Toolbox categories after flag flip + this PR: **11** — exactly the ones DEFAULT_CODEBIT_FILTERS marks `SHOW_BLOCK` (Display, Text, Input, Output, Timing, Sound, Loops, Logic, Math, Variables, Functions). Hidden: Accelerometer, RgbLed, Debug, Bits, Color, Console, Lists, Arrays — exactly the `HIDE_BLOCK` set.
- Restored the pre-Vite-migration FUSE behavior end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)