### PR TITLE
Fix FieldColorNumber crash when no palette is configured

### DIFF
--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -17,6 +17,19 @@ import { FieldCustom, FieldCustomOptions } from './field_utils';
  */
 export type FieldColourValueMode = "hex" | "rgb" | "index";
 
+/**
+ * Fallback palette used when a colour field is created without explicit
+ * `colours` field options and the target defines no `runtime.palette`. Older
+ * pxt tolerated a missing palette; without this guard makeSwatches() receives
+ * `undefined` and throws, which aborts the whole flyout layout (every block in
+ * the category is left unpositioned). This is the canonical MakeCode palette.
+ */
+const DEFAULT_COLOUR_PALETTE: string[] = [
+    "#000000", "#ffffff", "#ff2121", "#ff93c4", "#ff8135", "#fff609",
+    "#249ca3", "#78dc52", "#003fad", "#87f2ff", "#8e2ec4", "#a4839f",
+    "#5c406c", "#e5cdc4", "#91463d", "#000000"
+];
+
 export interface FieldColourNumberOptions extends FieldCustomOptions {
     colours?: string; // parsed as a JSON array
     columns?: string; // parsed as a number
@@ -63,6 +76,11 @@ export class FieldColorNumber extends FieldGridDropdown implements FieldCustom {
                 titles = pxt.Util.clone(pxt.appTarget.runtime.paletteNames);
                 titles[0] = lf("transparent");
             }
+        }
+        if (!allColoursCSSFormat) {
+            // No field-level colours and no target palette: fall back so
+            // makeSwatches doesn't throw and break the flyout layout.
+            allColoursCSSFormat = DEFAULT_COLOUR_PALETTE.slice();
         }
         super(makeSwatches(valueMode, allColoursCSSFormat, titles), opt_validator, {
             primaryColour: "white",


### PR DESCRIPTION
## Problem

In the Blockly toolbox flyout, any category containing a colour field renders **all** its blocks piled on top of each other at the flyout origin (overlapping, the widest block overflowing horizontally). In FUSE this hits the **Display** category.

## Root cause

`FieldColorNumber`'s constructor calls `makeSwatches(valueMode, allColoursCSSFormat, titles)`. When a colour field has **no `colours` field option** AND the target defines **no `runtime.palette`**, `allColoursCSSFormat` is left `undefined`, and `makeSwatches` does `allColoursCSSFormat.map(...)` →

```
TypeError: Cannot read properties of undefined (reading 'map')
  at makeSwatches (field_colour.ts)
  at new FieldColorNumber
  at createFieldEditor
```

Because the field is constructed during the flyout's `show()` block-inflation, this exception **aborts `show()` before `layout_` runs**, so every block in that category is left unpositioned (`transform=null`) and piles at the origin.

Older pxt tolerated a missing palette; this path regressed.

## Fix

Fall back to a default palette in the `FieldColorNumber` constructor when neither field `colours` nor `runtime.palette` is set, so `makeSwatches` never receives `undefined`. Targets that configure a palette are unaffected (it takes precedence).

## Verification

Built and re-vendored into the FUSE app. The Display flyout now stacks all blocks vertically with correct spacing, colour pickers render swatches, and switching between categories leaves no artifacts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)